### PR TITLE
feat: inline YouTube search and social link download

### DIFF
--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -56,38 +56,95 @@ async def check_access(message: types.Message, allowed_levels: list[Level]):
     return user
 
 @router.inline_query()
-async def inline_query_handler(inline_query: types.InlineQuery, logger):
+async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func):
     query = inline_query.query.strip()
     logger.trace(f'Inline Query: {query=}')
 
     articles = []
 
-    if 'tiktok.com' in query:
-        articles.append(
-            InlineQueryResultArticle(
-                id='1',
-                title="TikTok Download",
-                input_message_content=InputTextMessageContent(message_text="TikTok video is downloading..."),
-                description="Download the video from the provided TikTok link.",
-                reply_markup=types.InlineKeyboardMarkup(
-                    inline_keyboard=[[types.InlineKeyboardButton(
-                        text="Download",
-                        callback_data=CommonParamTick(title="TikTok", vid_data='ticktock_test').pack()
-                    )]]
+    if query.startswith('ssoc ') and len(query) > 5:
+        search_text = query[5:].strip()
+        if not search_text:
+            await inline_query.answer(results=[], cache_time=10)
+            return
+
+        logger.info(f'YouTube search via inline: {search_text}')
+        entries = bot_func.search_youtube(search_text, max_results=5)
+
+        for i, entry in enumerate(entries):
+            title = entry.get('title', 'No title')
+            channel = entry.get('channel', entry.get('uploader', 'Unknown'))
+            duration = entry.get('duration')
+            video_url = entry.get('url', '')
+
+            duration_str = ''
+            if duration:
+                mins, secs = divmod(int(duration), 60)
+                duration_str = f'{mins}:{secs:02d}'
+
+            description_parts = []
+            if duration_str:
+                description_parts.append(duration_str)
+            if channel:
+                description_parts.append(channel)
+            description = ' | '.join(description_parts) if description_parts else 'YouTube video'
+
+            articles.append(
+                InlineQueryResultArticle(
+                    id=str(i),
+                    title=title,
+                    input_message_content=InputTextMessageContent(
+                        message_text=video_url,
+                    ),
+                    description=description,
                 )
             )
-        )
-    else:
+
+        if not articles:
+            articles.append(
+                InlineQueryResultArticle(
+                    id='no_results',
+                    title='No results found',
+                    input_message_content=InputTextMessageContent(
+                        message_text='No YouTube results found.',
+                    ),
+                    description=f'No videos found for "{search_text}"',
+                )
+            )
+
+    elif any(domain in query for domain in ['tiktok.com', 'instagram.com', 'youtube.com', 'youtu.be']):
+        link = query.strip()
+        if 'tiktok.com' in link:
+            label = 'TikTok'
+        elif 'instagram.com' in link:
+            label = 'Instagram'
+        else:
+            label = 'YouTube'
+
         articles.append(
             InlineQueryResultArticle(
-                id='2',
-                title="Invalid Link",
-                input_message_content=InputTextMessageContent(message_text="This link is not supported."),
-                description="The provided link is not supported."
+                id='dl_social',
+                title=f'Download {label} video',
+                input_message_content=InputTextMessageContent(
+                    message_text=link,
+                ),
+                description=f'Download video from {label}',
             )
         )
 
-    await inline_query.answer(results=articles)
+    else:
+        articles.append(
+            InlineQueryResultArticle(
+                id='help',
+                title='How to use',
+                input_message_content=InputTextMessageContent(
+                    message_text='Use @bot ssoc <query> to search YouTube, or paste a TikTok/Instagram/YouTube link.',
+                ),
+                description='ssoc <query> | or paste a social link',
+            )
+        )
+
+    await inline_query.answer(results=articles, cache_time=10)
 
 
 @router.message(Command("test0"))

--- a/main.py
+++ b/main.py
@@ -73,7 +73,7 @@ async def start_user(message:types.Message):
 
 
 @dp.message(lambda msg: msg.text and any(link in msg.text for link in ['youtu.be', 'youtube.com']))
-async def cmd_numbers(message: types.Message):
+async def cmd_numbers(message: types.Message, cfg):
     user_bot = message.from_user
     link = ut.expand_url(message.text)
     link = link.split('&list')[0]
@@ -86,12 +86,59 @@ async def cmd_numbers(message: types.Message):
     user = ut.pandas2pydentic(df_t)
     available_memory = user.level.value - user.use_memory
     logger.info(f'User {user.id} {ut.get_name_from_pydantic(user)} has {ut.h_readable(available_memory)=}')
-    
+
     if available_memory < 0:
         await message.reply(f"Ви використали свій ліміт({ut.h_readable(user.level.value)})"+
                              f" на цей місяць, підніміть свій статус")
         return
-    
+
+    # If the message came via inline bot, auto-download best quality
+    if message.via_bot:
+        logger.info(f'Inline YouTube download for {user.id}: {link}')
+        environment = jinja2.Environment()
+        answer_template = environment.from_string(
+            "@{{bot_name}}\n\nУ тебе лишилося {{avail_mem}}\n\n{{progress_bar_str_value}}\n\n{{url}}"
+        )
+
+        current_date = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        loc_video = f"media/{user.id}/{current_date}"
+        ydl_opts = {
+            'format': 'bestvideo+bestaudio/best',
+            'outtmpl': loc_video,
+        }
+
+        res = await bot_func.get_dwn_media(ydl_opts, message, youtubeLink=link)
+        if not res:
+            await message.answer('Не вдалося завантажити. Перевір посилання і спробуй ще раз.')
+            logger.warning(f'Failed to download inline YouTube video {link}\n\n\n')
+            return
+        loc_video, file_size = res
+
+        available_memory -= file_size
+        total_mem_user_level = user.level.value
+        used_memory_per_user = user.use_memory
+
+        answer_cap = answer_template.render(
+            bot_name=cfg.shared_vars.bot_name,
+            avail_mem=ut.h_readable(available_memory),
+            progress_bar_str_value=ut.progress_bar_str(used_memory_per_user, total_mem_user_level),
+            url=link,
+        )
+
+        try:
+            await message.answer_video(
+                video=types.FSInputFile(loc_video), caption=answer_cap
+            )
+        except Exception as e:
+            await message.reply(f"An error occurred while sending the video: {e}")
+        user.use_memory += file_size
+        loc_match = glob.glob(os.path.join('.', f'{loc_video}*'))
+        assert loc_match
+        loc_video = loc_match[0]
+        ut.update_row(user)
+        ut.delete_video_file(loc_video)
+        return
+
     wait_bot_msg = await message.reply(f"Твоя лінка на youtube повідомлення опрацьовується!\
                                         У тебе лишилося {ut.h_readable(available_memory)}", disable_notification=True)
     logger.success(f'Хапнули лінку {link} --> {user.id} {ut.get_name_from_pydantic(user)}')
@@ -102,12 +149,12 @@ async def cmd_numbers(message: types.Message):
         logger.warning(f'Failed to download media formats with link {message.text}\n\n\n')
         return
 
-        
+
     yt_info, all_butons = res
     video_name = yt_info['title']
     id_video = yt_info['id']
     await message.reply(
-                        f"Яке хочете розширення? \n {link}\n повідомлення {user.full_name} \n\n" + 
+                        f"Яке хочете розширення? \n {link}\n повідомлення {user.full_name} \n\n" +
                         f"Vidoe --> {video_name}\nId --> {id_video} \n" +
                         f"У тебе лишилося {ut.h_readable(available_memory)}",
                         reply_markup=all_butons)

--- a/src/bot.py
+++ b/src/bot.py
@@ -42,6 +42,23 @@ class Bot_Func:
         self.log = log
         self.root_prj = root_prj
 
+    def search_youtube(self, query, max_results=5):
+        """Search YouTube using yt-dlp and return up to max_results entries."""
+        ydl_opts = {
+            'quiet': True,
+            'extract_flat': True,
+            'force_generic_extractor': False,
+        }
+        try:
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                result = ydl.extract_info(
+                    f"ytsearch{max_results}:{query}", download=False
+                )
+                return result.get('entries', [])
+        except Exception as e:
+            self.log.error(f"YouTube search error: {e}")
+            return []
+
 
 
     # TODO: remove from main


### PR DESCRIPTION
## Summary
- Add `@bot ssoc <query>` inline mode: searches YouTube via yt-dlp, shows up to 5 results with title, duration, and channel name
- Add `@bot <social_link>` inline mode: detects TikTok/Instagram/YouTube links and offers one-tap download
- YouTube links arriving via inline (`message.via_bot`) auto-download in best quality, skipping the format selection keyboard
- TikTok/Instagram links via inline are handled by the existing auto-download handler unchanged

## Changes
- `src/bot.py` — added `Bot_Func.search_youtube()` method using yt-dlp `ytsearch` with `extract_flat`
- `handlers/test_bot.py` — rewrote `inline_query_handler()` to handle `ssoc` prefix (YouTube search), social link detection, and help fallback
- `main.py` — added `message.via_bot` check in YouTube handler to auto-download best quality for inline-originated messages

## Test plan
- [ ] Enable inline mode for the bot in BotFather settings
- [ ] Test `@bot ssoc funny cats` — verify 5 YouTube results appear with title/duration/channel
- [ ] Select a result — verify video auto-downloads in best quality and is sent to the chat
- [ ] Test `@bot https://tiktok.com/...` — verify "Download TikTok video" appears
- [ ] Select it — verify video downloads and is sent
- [ ] Test `@bot https://youtube.com/...` — verify "Download YouTube video" appears and auto-downloads
- [ ] Test with unregistered user — verify proper error handling
- [ ] Test with user at memory limit — verify limit error is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)