### PR TITLE
fix: inline download via callback buttons

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: Lint
+
+on:
+  push:
+    branches: [master, dev]
+  pull_request:
+    branches: [master, dev]
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install ruff==0.11.6
+
+      # Critical rules — these catch code that is broken and will crash at runtime.
+      # The build FAILS if any of these are found.
+      #
+      # E9  — Syntax errors (IndentationError, invalid Python — code won't even parse)
+      # F63 — Invalid comparisons (e.g. `x is "string"`, `if x == []:` — bugs hiding as logic)
+      # F7  — Control flow mistakes (break/continue outside loop, return outside function)
+      # F82 — Undefined names (using a variable/function that doesn't exist — NameError at runtime)
+      - name: Critical errors (blocking)
+        run: ruff check --select E9,F63,F7,F82 .
+
+      # Everything else — style issues, unused imports, line length, etc.
+      # Reported for visibility but does NOT fail the build.
+      # `|| true` ensures the step always succeeds regardless of ruff's exit code.
+      - name: Style warnings (non-blocking)
+        run: ruff check . || true

--- a/handlers/media_bot.py
+++ b/handlers/media_bot.py
@@ -141,7 +141,6 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
 
     await callback_query.answer("Downloading...")
 
-    # Update the inline message to show download status
     inline_msg_id = callback_query.inline_message_id
     if inline_msg_id:
         try:
@@ -190,30 +189,50 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
     )
 
     try:
-        if loc_video.endswith('mp3') or loc_video.endswith('m4a'):
-            await bot.send_audio(
+        is_audio = loc_video.endswith('mp3') or loc_video.endswith('m4a')
+
+        if is_audio:
+            dm_msg = await bot.send_audio(
                 chat_id=user_id,
                 audio=types.FSInputFile(loc_video),
                 caption=f'@{cfg.shared_vars.bot_name}',
             )
         else:
-            await bot.send_video(
+            dm_msg = await bot.send_video(
                 chat_id=user_id,
                 video=types.FSInputFile(loc_video),
                 caption=answer_cap,
             )
+
+        # Replace the inline message with the actual video/audio
+        if inline_msg_id and dm_msg:
+            try:
+                if is_audio and dm_msg.audio:
+                    media = types.InputMediaAudio(
+                        media=dm_msg.audio.file_id,
+                        caption=f'@{cfg.shared_vars.bot_name}',
+                    )
+                elif dm_msg.video:
+                    media = types.InputMediaVideo(
+                        media=dm_msg.video.file_id,
+                        caption=answer_cap,
+                    )
+                else:
+                    media = None
+
+                if media:
+                    await bot.edit_message_media(
+                        media=media,
+                        inline_message_id=inline_msg_id,
+                    )
+                    # Delete the DM copy since video is now in the chat
+                    await dm_msg.delete()
+            except Exception as e:
+                logger.warning(f'Could not edit inline message with media: {e}')
+                # DM copy stays as fallback
+
     except Exception as e:
         await bot.send_message(user_id, f"Error sending video: {e}")
-
-    # Update inline message to show completion
-    if inline_msg_id:
-        try:
-            await bot.edit_message_text(
-                "Video sent to your DM",
-                inline_message_id=inline_msg_id,
-            )
-        except Exception:
-            pass
 
     user.use_memory += file_size
     ut.update_row(user)

--- a/handlers/media_bot.py
+++ b/handlers/media_bot.py
@@ -205,31 +205,34 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
             )
 
         # Replace the inline message with the actual video/audio
+        logger.info(f'inline_msg_id={inline_msg_id}, has_video={bool(dm_msg.video)}, '
+                     f'has_document={bool(dm_msg.document)}, has_audio={bool(dm_msg.audio)}')
         if inline_msg_id and dm_msg:
-            try:
-                if is_audio and dm_msg.audio:
-                    media = types.InputMediaAudio(
-                        media=dm_msg.audio.file_id,
-                        caption=f'@{cfg.shared_vars.bot_name}',
-                    )
-                elif dm_msg.video:
-                    media = types.InputMediaVideo(
-                        media=dm_msg.video.file_id,
-                        caption=answer_cap,
-                    )
-                else:
-                    media = None
+            file_id = None
+            if is_audio and dm_msg.audio:
+                file_id = dm_msg.audio.file_id
+                media = types.InputMediaAudio(media=file_id, caption=f'@{cfg.shared_vars.bot_name}')
+            elif dm_msg.video:
+                file_id = dm_msg.video.file_id
+                media = types.InputMediaVideo(media=file_id, caption=answer_cap)
+            elif dm_msg.document:
+                file_id = dm_msg.document.file_id
+                media = types.InputMediaDocument(media=file_id, caption=answer_cap)
+            else:
+                media = None
 
-                if media:
+            logger.info(f'edit_message_media: file_id={bool(file_id)}, media_type={type(media).__name__ if media else None}')
+            if media:
+                try:
                     await bot.edit_message_media(
                         media=media,
                         inline_message_id=inline_msg_id,
                     )
-                    # Delete the DM copy since video is now in the chat
                     await dm_msg.delete()
-            except Exception as e:
-                logger.warning(f'Could not edit inline message with media: {e}')
-                # DM copy stays as fallback
+                    logger.info('Inline message replaced with video successfully')
+                except Exception as e:
+                    logger.error(f'edit_message_media failed: {e}')
+                    # DM copy stays as fallback
 
     except Exception as e:
         await bot.send_message(user_id, f"Error sending video: {e}")

--- a/handlers/media_bot.py
+++ b/handlers/media_bot.py
@@ -3,14 +3,32 @@ from aiogram import F, Bot, types, Router
 from src.bot import CommonParamYouTube, CommonParamInline
 import jinja2
 from src import utils as ut
-import os
-import glob
-
-
-from handlers.test_bot import CommonParamTick
 
 
 router_med = Router()
+
+_YDL_OPTS_BY_MODE = {
+    'audio': {
+        'format': 'bestaudio/best',
+        'postprocessors': [{
+            'key': 'FFmpegExtractAudio',
+            'preferredcodec': 'mp3',
+            'preferredquality': '192',
+        }],
+    },
+    'video': {
+        'format': 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best',
+        'merge_output_format': 'mp4',
+    },
+    'social': {
+        'format': 'bestvideo+bestaudio/best',
+        'merge_output_format': 'mp4',
+    },
+}
+
+_CAPTION_TEMPLATE = jinja2.Environment().from_string(
+    "@{{bot_name}}\n\nУ тебе лишилося {{avail_mem}}\n\n{{progress_bar_str_value}}\n\n{{url}}"
+)
 # BOT_NAME = 'med_soc_bot'
 
 
@@ -109,13 +127,6 @@ async def handle_callback(callback_query: types.CallbackQuery, logger, user_data
 
 
 
-@router_med.callback_query(F.data.startswith("tick"))
-async def handle_callback_reel(callback_query: types.CallbackQuery, logger, user_data, bot_func):
-    cb1 = CommonParamTick.unpack(callback_query.data)
-    logger.info(f'callback catch {cb1}')
-    await callback_query.answer("This button is outdated, use the new inline search.")
-
-
 @router_med.callback_query(F.data.startswith("idl"))
 async def handle_inline_download(callback_query: types.CallbackQuery, logger, user_data, bot_func, cfg, bot: Bot):
     cb = CommonParamInline.unpack(callback_query.data)
@@ -126,27 +137,20 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
         await callback_query.answer("Link expired. Try searching again.")
         return
 
-    # Support both old format (string) and new format (dict)
-    if isinstance(data, str):
-        url = data
-        mode = 'social'
-        media_title = ''
-    else:
-        url = data['url']
-        mode = data.get('mode', 'social')
-        media_title = data.get('title', '')
+    url = data['url']
+    mode = data.get('mode', 'social')
+    media_title = data.get('title', '')
 
-    user_bot = callback_query.from_user
-    user_id = user_bot.id
+    user_id = callback_query.from_user.id
     df_t = ut.get_user_by_id(user_id)
     if df_t.empty:
-        await callback_query.answer("You are not registered. Send /start to the bot first.")
+        await callback_query.answer("Ти не зареганий натисни /start")
         return
 
     user = ut.pandas2pydentic(df_t)
     available_memory = user.level.value - user.use_memory
     if available_memory < 0:
-        await callback_query.answer("You've exceeded your download limit.")
+        await callback_query.answer("Ви використали свій ліміт на цей місяць")
         return
 
     await callback_query.answer("Downloading...")
@@ -154,63 +158,29 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
     inline_msg_id = callback_query.inline_message_id
     if inline_msg_id:
         try:
-            await bot.edit_message_text(
-                "Downloading...",
-                inline_message_id=inline_msg_id,
-            )
-        except Exception:
-            pass
+            await bot.edit_message_text("Downloading...", inline_message_id=inline_msg_id)
+        except Exception as e:
+            logger.debug(f'edit inline status failed: {e}')
 
     status_msg = await bot.send_message(user_id, "Start downloading ...")
 
-    environment = jinja2.Environment()
-    answer_template = environment.from_string(
-        "@{{bot_name}}\n\nУ тебе лишилося {{avail_mem}}\n\n{{progress_bar_str_value}}\n\n{{url}}"
-    )
-
-    current_date = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    loc_media = f"media/{user_id}/{current_date}"
-
-    if mode == 'audio':
-        ydl_opts = {
-            'format': 'bestaudio/best',
-            'outtmpl': loc_media,
-            'postprocessors': [{
-                'key': 'FFmpegExtractAudio',
-                'preferredcodec': 'mp3',
-                'preferredquality': '192',
-            }],
-        }
-    elif mode == 'video':
-        ydl_opts = {
-            'format': 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best',
-            'outtmpl': loc_media,
-            'merge_output_format': 'mp4',
-        }
-    else:  # social
-        ydl_opts = {
-            'format': 'bestvideo+bestaudio/best',
-            'outtmpl': loc_media,
-            'merge_output_format': 'mp4',
-        }
+    loc_media = f"media/{user_id}/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
+    ydl_opts = {**_YDL_OPTS_BY_MODE[mode], 'outtmpl': loc_media}
 
     res = await bot_func.get_dwn_media(ydl_opts, status_msg, youtubeLink=url)
     if not res:
-        await bot.send_message(user_id, 'Failed to download. Check the link and try again.')
+        await bot.send_message(user_id, 'Не вдалося завантажити. Перевір посилання і спробуй ще раз.')
         if inline_msg_id:
             try:
-                await bot.edit_message_text(
-                    "Download failed",
-                    inline_message_id=inline_msg_id,
-                )
-            except Exception:
-                pass
+                await bot.edit_message_text("Download failed", inline_message_id=inline_msg_id)
+            except Exception as e:
+                logger.debug(f'edit inline failure status failed: {e}')
         logger.warning(f'Failed inline download {url} for user {user_id}')
         return
     loc_media, file_size = res
 
     available_memory -= file_size
-    answer_cap = answer_template.render(
+    answer_cap = _CAPTION_TEMPLATE.render(
         bot_name=cfg.shared_vars.bot_name,
         avail_mem=ut.h_readable(available_memory),
         progress_bar_str_value=ut.progress_bar_str(user.use_memory, user.level.value),
@@ -218,9 +188,7 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
     )
 
     try:
-        is_audio = loc_media.endswith('mp3') or loc_media.endswith('m4a')
-
-        if is_audio:
+        if mode == 'audio':
             dm_msg = await bot.send_audio(
                 chat_id=user_id,
                 audio=types.FSInputFile(loc_media),
@@ -234,32 +202,23 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
                 caption=answer_cap,
             )
 
-        # Replace the inline message with the actual video/audio
-        logger.info(f'inline_msg_id={inline_msg_id}, has_video={bool(dm_msg.video)}, '
-                     f'has_document={bool(dm_msg.document)}, has_audio={bool(dm_msg.audio)}')
         if inline_msg_id and dm_msg:
-            file_id = None
-            if is_audio and dm_msg.audio:
-                file_id = dm_msg.audio.file_id
-                media = types.InputMediaAudio(media=file_id, caption=f'@{cfg.shared_vars.bot_name}')
+            if mode == 'audio' and dm_msg.audio:
+                media = types.InputMediaAudio(
+                    media=dm_msg.audio.file_id,
+                    caption=f'@{cfg.shared_vars.bot_name}',
+                )
             elif dm_msg.video:
-                file_id = dm_msg.video.file_id
-                media = types.InputMediaVideo(media=file_id, caption=answer_cap)
+                media = types.InputMediaVideo(media=dm_msg.video.file_id, caption=answer_cap)
             elif dm_msg.document:
-                file_id = dm_msg.document.file_id
-                media = types.InputMediaDocument(media=file_id, caption=answer_cap)
+                media = types.InputMediaDocument(media=dm_msg.document.file_id, caption=answer_cap)
             else:
                 media = None
 
-            logger.info(f'edit_message_media: file_id={bool(file_id)}, media_type={type(media).__name__ if media else None}')
             if media:
                 try:
-                    await bot.edit_message_media(
-                        media=media,
-                        inline_message_id=inline_msg_id,
-                    )
+                    await bot.edit_message_media(media=media, inline_message_id=inline_msg_id)
                     await dm_msg.delete()
-                    logger.info('Inline message replaced with media successfully')
                 except Exception as e:
                     logger.error(f'edit_message_media failed: {e}')
 
@@ -268,9 +227,6 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
 
     user.use_memory += file_size
     ut.update_row(user)
-
-    loc_match = glob.glob(os.path.join('.', f'{loc_media}*'))
-    if loc_match:
-        ut.delete_video_file(loc_match[0])
+    ut.delete_video_file(loc_media)
 
     user_data.pop(cb.key, None)

--- a/handlers/media_bot.py
+++ b/handlers/media_bot.py
@@ -130,9 +130,11 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
     if isinstance(data, str):
         url = data
         mode = 'social'
+        media_title = ''
     else:
         url = data['url']
         mode = data.get('mode', 'social')
+        media_title = data.get('title', '')
 
     user_bot = callback_query.from_user
     user_id = user_bot.id
@@ -172,7 +174,7 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
     if mode == 'audio':
         ydl_opts = {
             'format': 'bestaudio/best',
-            'outtmpl': f"media/{user_id}/%(title)s",
+            'outtmpl': loc_media,
             'postprocessors': [{
                 'key': 'FFmpegExtractAudio',
                 'preferredcodec': 'mp3',
@@ -222,6 +224,7 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
             dm_msg = await bot.send_audio(
                 chat_id=user_id,
                 audio=types.FSInputFile(loc_media),
+                title=media_title or None,
                 caption=f'@{cfg.shared_vars.bot_name}',
             )
         else:

--- a/handlers/media_bot.py
+++ b/handlers/media_bot.py
@@ -119,12 +119,20 @@ async def handle_callback_reel(callback_query: types.CallbackQuery, logger, user
 @router_med.callback_query(F.data.startswith("idl"))
 async def handle_inline_download(callback_query: types.CallbackQuery, logger, user_data, bot_func, cfg, bot: Bot):
     cb = CommonParamInline.unpack(callback_query.data)
-    url = user_data.get(cb.key)
-    logger.info(f'Inline download callback: {cb.key=} {url=}')
+    data = user_data.get(cb.key)
+    logger.info(f'Inline download callback: {cb.key=} {data=}')
 
-    if not url:
+    if not data:
         await callback_query.answer("Link expired. Try searching again.")
         return
+
+    # Support both old format (string) and new format (dict)
+    if isinstance(data, str):
+        url = data
+        mode = 'social'
+    else:
+        url = data['url']
+        mode = data.get('mode', 'social')
 
     user_bot = callback_query.from_user
     user_id = user_bot.id
@@ -159,11 +167,30 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
     )
 
     current_date = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    loc_video = f"media/{user_id}/{current_date}"
-    ydl_opts = {
-        'format': 'bestvideo+bestaudio/best',
-        'outtmpl': loc_video,
-    }
+    loc_media = f"media/{user_id}/{current_date}"
+
+    if mode == 'audio':
+        ydl_opts = {
+            'format': 'bestaudio/best',
+            'outtmpl': loc_media,
+            'postprocessors': [{
+                'key': 'FFmpegExtractAudio',
+                'preferredcodec': 'mp3',
+                'preferredquality': '192',
+            }],
+        }
+    elif mode == 'video':
+        ydl_opts = {
+            'format': 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best',
+            'outtmpl': loc_media,
+            'merge_output_format': 'mp4',
+        }
+    else:  # social
+        ydl_opts = {
+            'format': 'bestvideo+bestaudio/best',
+            'outtmpl': loc_media,
+            'merge_output_format': 'mp4',
+        }
 
     res = await bot_func.get_dwn_media(ydl_opts, status_msg, youtubeLink=url)
     if not res:
@@ -178,7 +205,7 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
                 pass
         logger.warning(f'Failed inline download {url} for user {user_id}')
         return
-    loc_video, file_size = res
+    loc_media, file_size = res
 
     available_memory -= file_size
     answer_cap = answer_template.render(
@@ -189,18 +216,18 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
     )
 
     try:
-        is_audio = loc_video.endswith('mp3') or loc_video.endswith('m4a')
+        is_audio = loc_media.endswith('mp3') or loc_media.endswith('m4a')
 
         if is_audio:
             dm_msg = await bot.send_audio(
                 chat_id=user_id,
-                audio=types.FSInputFile(loc_video),
+                audio=types.FSInputFile(loc_media),
                 caption=f'@{cfg.shared_vars.bot_name}',
             )
         else:
             dm_msg = await bot.send_video(
                 chat_id=user_id,
-                video=types.FSInputFile(loc_video),
+                video=types.FSInputFile(loc_media),
                 caption=answer_cap,
             )
 
@@ -229,18 +256,17 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
                         inline_message_id=inline_msg_id,
                     )
                     await dm_msg.delete()
-                    logger.info('Inline message replaced with video successfully')
+                    logger.info('Inline message replaced with media successfully')
                 except Exception as e:
                     logger.error(f'edit_message_media failed: {e}')
-                    # DM copy stays as fallback
 
     except Exception as e:
-        await bot.send_message(user_id, f"Error sending video: {e}")
+        await bot.send_message(user_id, f"Error sending media: {e}")
 
     user.use_memory += file_size
     ut.update_row(user)
 
-    loc_match = glob.glob(os.path.join('.', f'{loc_video}*'))
+    loc_match = glob.glob(os.path.join('.', f'{loc_media}*'))
     if loc_match:
         ut.delete_video_file(loc_match[0])
 

--- a/handlers/media_bot.py
+++ b/handlers/media_bot.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from aiogram import F, types, Router
+from aiogram import F, Bot, types, Router
 from src.bot import CommonParamYouTube, CommonParamInline
 import jinja2
 from src import utils as ut
@@ -117,7 +117,7 @@ async def handle_callback_reel(callback_query: types.CallbackQuery, logger, user
 
 
 @router_med.callback_query(F.data.startswith("idl"))
-async def handle_inline_download(callback_query: types.CallbackQuery, logger, user_data, bot_func, cfg):
+async def handle_inline_download(callback_query: types.CallbackQuery, logger, user_data, bot_func, cfg, bot: Bot):
     cb = CommonParamInline.unpack(callback_query.data)
     url = user_data.get(cb.key)
     logger.info(f'Inline download callback: {cb.key=} {url=}')
@@ -127,7 +127,8 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
         return
 
     user_bot = callback_query.from_user
-    df_t = ut.get_user_by_id(user_bot.id)
+    user_id = user_bot.id
+    df_t = ut.get_user_by_id(user_id)
     if df_t.empty:
         await callback_query.answer("You are not registered. Send /start to the bot first.")
         return
@@ -140,7 +141,8 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
 
     await callback_query.answer()
 
-    bot_msg = callback_query.message
+    # Inline callbacks have message=None, so send status to user's DM
+    status_msg = await bot.send_message(user_id, "Start downloading ...")
 
     environment = jinja2.Environment()
     answer_template = environment.from_string(
@@ -148,16 +150,16 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
     )
 
     current_date = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    loc_video = f"media/{user.id}/{current_date}"
+    loc_video = f"media/{user_id}/{current_date}"
     ydl_opts = {
         'format': 'bestvideo+bestaudio/best',
         'outtmpl': loc_video,
     }
 
-    res = await bot_func.get_dwn_media(ydl_opts, bot_msg, youtubeLink=url)
+    res = await bot_func.get_dwn_media(ydl_opts, status_msg, youtubeLink=url)
     if not res:
-        await bot_msg.answer('Failed to download. Check the link and try again.')
-        logger.warning(f'Failed inline download {url} for user {user.id}')
+        await bot.send_message(user_id, 'Failed to download. Check the link and try again.')
+        logger.warning(f'Failed inline download {url} for user {user_id}')
         return
     loc_video, file_size = res
 
@@ -171,17 +173,19 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
 
     try:
         if loc_video.endswith('mp3') or loc_video.endswith('m4a'):
-            await bot_msg.answer_audio(
+            await bot.send_audio(
+                chat_id=user_id,
                 audio=types.FSInputFile(loc_video),
                 caption=f'@{cfg.shared_vars.bot_name}',
             )
         else:
-            await bot_msg.answer_video(
+            await bot.send_video(
+                chat_id=user_id,
                 video=types.FSInputFile(loc_video),
                 caption=answer_cap,
             )
     except Exception as e:
-        await bot_msg.reply(f"Error sending video: {e}")
+        await bot.send_message(user_id, f"Error sending video: {e}")
 
     user.use_memory += file_size
     ut.update_row(user)
@@ -190,5 +194,4 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
     if loc_match:
         ut.delete_video_file(loc_match[0])
 
-    # Clean up the stored URL
     user_data.pop(cb.key, None)

--- a/handlers/media_bot.py
+++ b/handlers/media_bot.py
@@ -1,6 +1,6 @@
 from datetime import datetime
-from aiogram import F, Bot, Dispatcher, types, Router
-from src.bot import CommonParamYouTube
+from aiogram import F, types, Router
+from src.bot import CommonParamYouTube, CommonParamInline
 import jinja2
 from src import utils as ut
 import os
@@ -70,7 +70,7 @@ async def handle_callback(callback_query: types.CallbackQuery, logger, user_data
         logger.warning(f'Failed to download media with link {youtube_url}\n\n\n')
         return
     loc_media, file_size = res
-    info_wait_button = await bot_msg.reply(f"✅ Download successful!\nSending video", disable_notification=True)
+    info_wait_button = await bot_msg.reply("✅ Download successful!\nSending video", disable_notification=True)
     # loc_match = glob.glob(os.path.join('.', f'{loc_media}*'))
     # assert loc_match
     # loc_video  = loc_match[0]
@@ -112,8 +112,83 @@ async def handle_callback(callback_query: types.CallbackQuery, logger, user_data
 @router_med.callback_query(F.data.startswith("tick"))
 async def handle_callback_reel(callback_query: types.CallbackQuery, logger, user_data, bot_func):
     cb1 = CommonParamTick.unpack(callback_query.data)
-    title = cb1.title
-    vid_data = cb1.vid_data
-    # logger.trace(f'{cb1=}')
-
     logger.info(f'callback catch {cb1}')
+    await callback_query.answer("This button is outdated, use the new inline search.")
+
+
+@router_med.callback_query(F.data.startswith("idl"))
+async def handle_inline_download(callback_query: types.CallbackQuery, logger, user_data, bot_func, cfg):
+    cb = CommonParamInline.unpack(callback_query.data)
+    url = user_data.get(cb.key)
+    logger.info(f'Inline download callback: {cb.key=} {url=}')
+
+    if not url:
+        await callback_query.answer("Link expired. Try searching again.")
+        return
+
+    user_bot = callback_query.from_user
+    df_t = ut.get_user_by_id(user_bot.id)
+    if df_t.empty:
+        await callback_query.answer("You are not registered. Send /start to the bot first.")
+        return
+
+    user = ut.pandas2pydentic(df_t)
+    available_memory = user.level.value - user.use_memory
+    if available_memory < 0:
+        await callback_query.answer("You've exceeded your download limit.")
+        return
+
+    await callback_query.answer()
+
+    bot_msg = callback_query.message
+
+    environment = jinja2.Environment()
+    answer_template = environment.from_string(
+        "@{{bot_name}}\n\nУ тебе лишилося {{avail_mem}}\n\n{{progress_bar_str_value}}\n\n{{url}}"
+    )
+
+    current_date = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    loc_video = f"media/{user.id}/{current_date}"
+    ydl_opts = {
+        'format': 'bestvideo+bestaudio/best',
+        'outtmpl': loc_video,
+    }
+
+    res = await bot_func.get_dwn_media(ydl_opts, bot_msg, youtubeLink=url)
+    if not res:
+        await bot_msg.answer('Failed to download. Check the link and try again.')
+        logger.warning(f'Failed inline download {url} for user {user.id}')
+        return
+    loc_video, file_size = res
+
+    available_memory -= file_size
+    answer_cap = answer_template.render(
+        bot_name=cfg.shared_vars.bot_name,
+        avail_mem=ut.h_readable(available_memory),
+        progress_bar_str_value=ut.progress_bar_str(user.use_memory, user.level.value),
+        url=url,
+    )
+
+    try:
+        if loc_video.endswith('mp3') or loc_video.endswith('m4a'):
+            await bot_msg.answer_audio(
+                audio=types.FSInputFile(loc_video),
+                caption=f'@{cfg.shared_vars.bot_name}',
+            )
+        else:
+            await bot_msg.answer_video(
+                video=types.FSInputFile(loc_video),
+                caption=answer_cap,
+            )
+    except Exception as e:
+        await bot_msg.reply(f"Error sending video: {e}")
+
+    user.use_memory += file_size
+    ut.update_row(user)
+
+    loc_match = glob.glob(os.path.join('.', f'{loc_video}*'))
+    if loc_match:
+        ut.delete_video_file(loc_match[0])
+
+    # Clean up the stored URL
+    user_data.pop(cb.key, None)

--- a/handlers/media_bot.py
+++ b/handlers/media_bot.py
@@ -139,9 +139,19 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
         await callback_query.answer("You've exceeded your download limit.")
         return
 
-    await callback_query.answer()
+    await callback_query.answer("Downloading...")
 
-    # Inline callbacks have message=None, so send status to user's DM
+    # Update the inline message to show download status
+    inline_msg_id = callback_query.inline_message_id
+    if inline_msg_id:
+        try:
+            await bot.edit_message_text(
+                "Downloading...",
+                inline_message_id=inline_msg_id,
+            )
+        except Exception:
+            pass
+
     status_msg = await bot.send_message(user_id, "Start downloading ...")
 
     environment = jinja2.Environment()
@@ -159,6 +169,14 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
     res = await bot_func.get_dwn_media(ydl_opts, status_msg, youtubeLink=url)
     if not res:
         await bot.send_message(user_id, 'Failed to download. Check the link and try again.')
+        if inline_msg_id:
+            try:
+                await bot.edit_message_text(
+                    "Download failed",
+                    inline_message_id=inline_msg_id,
+                )
+            except Exception:
+                pass
         logger.warning(f'Failed inline download {url} for user {user_id}')
         return
     loc_video, file_size = res
@@ -186,6 +204,16 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
             )
     except Exception as e:
         await bot.send_message(user_id, f"Error sending video: {e}")
+
+    # Update inline message to show completion
+    if inline_msg_id:
+        try:
+            await bot.edit_message_text(
+                "Video sent to your DM",
+                inline_message_id=inline_msg_id,
+            )
+        except Exception:
+            pass
 
     user.use_memory += file_size
     ut.update_row(user)

--- a/handlers/media_bot.py
+++ b/handlers/media_bot.py
@@ -172,7 +172,7 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
     if mode == 'audio':
         ydl_opts = {
             'format': 'bestaudio/best',
-            'outtmpl': loc_media,
+            'outtmpl': f"media/{user_id}/%(title)s",
             'postprocessors': [{
                 'key': 'FFmpegExtractAudio',
                 'preferredcodec': 'mp3',

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -126,7 +126,7 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
                 thumbnail = f'https://i.ytimg.com/vi/{video_id}/hqdefault.jpg' if video_id else ''
 
                 key = f"inl_{user_id}_{i}"
-                user_data[key] = {'url': video_url, 'mode': mode}
+                user_data[key] = {'url': video_url, 'mode': mode, 'title': title}
 
                 duration_str = ''
                 if duration:

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -1,15 +1,12 @@
-from aiogram import F, Bot, Dispatcher, types, Router
+from aiogram import Bot, types, Router
 from aiogram.enums import ParseMode
 from aiogram.types import Message
-from aiogram.types import InlineQuery, InlineQueryResultArticle, InputTextMessageContent, InlineKeyboardMarkup, InlineKeyboardButton
-from uuid import uuid4
+from aiogram.types import InlineQueryResultArticle, InputTextMessageContent, InlineKeyboardMarkup, InlineKeyboardButton
 import html
 from aiogram.filters.command import Command
 from aiogram.filters.callback_data import CallbackData
 from aiogram.utils.markdown import hide_link
-from aiogram.fsm.storage.memory import MemoryStorage
-from src.bot import CommonParamYouTube
-from src.MiddleWare import SharedContextMiddleware
+from src.bot import CommonParamInline
 from src import utils as ut
 import pandas as pd
 from src.Users import Level
@@ -56,8 +53,9 @@ async def check_access(message: types.Message, allowed_levels: list[Level]):
     return user
 
 @router.inline_query()
-async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func):
+async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func, user_data):
     query = inline_query.query.strip()
+    user_id = inline_query.from_user.id
     logger.trace(f'Inline Query: {query=}')
 
     articles = []
@@ -77,6 +75,9 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
             duration = entry.get('duration')
             video_url = entry.get('url', '')
 
+            key = f"inl_{user_id}_{i}"
+            user_data[key] = video_url
+
             duration_str = ''
             if duration:
                 mins, secs = divmod(int(duration), 60)
@@ -89,14 +90,21 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
                 description_parts.append(channel)
             description = ' | '.join(description_parts) if description_parts else 'YouTube video'
 
+            cb = CommonParamInline(key=key)
             articles.append(
                 InlineQueryResultArticle(
                     id=str(i),
                     title=title,
                     input_message_content=InputTextMessageContent(
-                        message_text=video_url,
+                        message_text=f"{title}\n{video_url}",
                     ),
                     description=description,
+                    reply_markup=InlineKeyboardMarkup(
+                        inline_keyboard=[[InlineKeyboardButton(
+                            text="Download",
+                            callback_data=cb.pack(),
+                        )]]
+                    ),
                 )
             )
 
@@ -121,14 +129,24 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
         else:
             label = 'YouTube'
 
+        key = f"inl_{user_id}_social"
+        user_data[key] = link
+        cb = CommonParamInline(key=key)
+
         articles.append(
             InlineQueryResultArticle(
                 id='dl_social',
                 title=f'Download {label} video',
                 input_message_content=InputTextMessageContent(
-                    message_text=link,
+                    message_text=f"Downloading {label} video...\n{link}",
                 ),
                 description=f'Download video from {label}',
+                reply_markup=InlineKeyboardMarkup(
+                    inline_keyboard=[[InlineKeyboardButton(
+                        text="Download",
+                        callback_data=cb.pack(),
+                    )]]
+                ),
             )
         )
 
@@ -173,7 +191,7 @@ async def cmd_test2(message: types.Message, logger):
 async def cmd_reset_memory(message: types.Message, logger, cfg, bot: Bot):
     caller = message.from_user
     if ut.get_user_by_id(caller.id).empty:
-        await message.reply(f"Ти не зареганий натисни /start")
+        await message.reply("Ти не зареганий натисни /start")
         return
     logger.info(f'User {caller.id} {caller.full_name} run to clear memory')
 
@@ -198,7 +216,7 @@ async def cmd_reset_memory(message: types.Message, logger, cfg, bot: Bot):
         logger.info(f'Notification sent to {target_id}')
     except IndexError:
         logger.info(f'{target_id} dont reg')
-        await message.answer(f"Ти не зареганий натисни /start")
+        await message.answer("Ти не зареганий натисни /start")
     except Exception as e:
         logger.exception(f'{target_id} dont reg')
         await message.answer(f"помилка {e}")
@@ -208,7 +226,7 @@ async def cmd_me(message: types.Message):
     user_bot = message.from_user
     df_t = ut.get_user_by_id(user_bot.id)
     if df_t.empty:
-        await message.reply(f"Ти не зареганий натисни /start")
+        await message.reply("Ти не зареганий натисни /start")
         return
     user = ut.pandas2pydentic(df_t)
     total_mb = round(user.level.value/(1024**2), 2)

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -86,9 +86,21 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
                 mins, secs = divmod(int(duration), 60)
                 duration_str = f'{mins}:{secs:02d}'
 
+            view_count = entry.get('view_count')
+            views_str = ''
+            if view_count:
+                if view_count >= 1_000_000:
+                    views_str = f'{view_count / 1_000_000:.1f}M views'
+                elif view_count >= 1_000:
+                    views_str = f'{view_count / 1_000:.1f}K views'
+                else:
+                    views_str = f'{view_count} views'
+
             description_parts = []
             if duration_str:
                 description_parts.append(duration_str)
+            if views_str:
+                description_parts.append(views_str)
             if channel:
                 description_parts.append(channel)
             description = ' | '.join(description_parts) if description_parts else 'YouTube video'

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -73,8 +73,10 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
             title = entry.get('title', 'No title')
             channel = entry.get('channel', entry.get('uploader', 'Unknown'))
             duration = entry.get('duration')
-            video_url = entry.get('webpage_url') or entry.get('original_url', '')
-            thumbnail = entry.get('thumbnail', '')
+            video_url = entry.get('url') or entry.get('webpage_url', '')
+            # Flat extraction: build thumbnail from video ID
+            video_id = entry.get('id', '')
+            thumbnail = f'https://i.ytimg.com/vi/{video_id}/hqdefault.jpg' if video_id else ''
 
             key = f"inl_{user_id}_{i}"
             user_data[key] = video_url

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -60,97 +60,15 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
 
     articles = []
 
-    if query.startswith('ssoc ') and len(query) > 5:
-        search_text = query[5:].strip()
-        if not search_text:
-            await inline_query.answer(results=[], cache_time=10)
-            return
-
-        logger.info(f'YouTube search via inline: {search_text}')
-        entries = bot_func.search_youtube(search_text, max_results=3)
-
-        for i, entry in enumerate(entries):
-            title = entry.get('title', 'No title')
-            channel = entry.get('channel', entry.get('uploader', 'Unknown'))
-            duration = entry.get('duration')
-            video_url = entry.get('url') or entry.get('webpage_url', '')
-            # Flat extraction: build thumbnail from video ID
-            video_id = entry.get('id', '')
-            thumbnail = f'https://i.ytimg.com/vi/{video_id}/hqdefault.jpg' if video_id else ''
-
-            key = f"inl_{user_id}_{i}"
-            user_data[key] = video_url
-
-            duration_str = ''
-            if duration:
-                mins, secs = divmod(int(duration), 60)
-                duration_str = f'{mins}:{secs:02d}'
-
-            view_count = entry.get('view_count')
-            views_str = ''
-            if view_count:
-                if view_count >= 1_000_000:
-                    views_str = f'{view_count / 1_000_000:.1f}M views'
-                elif view_count >= 1_000:
-                    views_str = f'{view_count / 1_000:.1f}K views'
-                else:
-                    views_str = f'{view_count} views'
-
-            description_parts = []
-            if duration_str:
-                description_parts.append(duration_str)
-            if views_str:
-                description_parts.append(views_str)
-            if channel:
-                description_parts.append(channel)
-            description = ' | '.join(description_parts) if description_parts else 'YouTube video'
-
-            thumb = thumbnail or 'https://placehold.co/320x180.png'
-            cb = CommonParamInline(key=key)
-            articles.append(
-                InlineQueryResultArticle(
-                    id=str(i),
-                    title=title,
-                    input_message_content=InputTextMessageContent(
-                        message_text=f"{title}\n{video_url}",
-                    ),
-                    description=description,
-                    thumbnail_url=thumb,
-                    reply_markup=InlineKeyboardMarkup(
-                        inline_keyboard=[[InlineKeyboardButton(
-                            text="Download",
-                            callback_data=cb.pack(),
-                        )]]
-                    ),
-                )
-            )
-
-        if not articles:
-            articles.append(
-                InlineQueryResultArticle(
-                    id='no_results',
-                    title='No results found',
-                    input_message_content=InputTextMessageContent(
-                        message_text='No YouTube results found.',
-                    ),
-                    description=f'No videos found for "{search_text}"',
-                )
-            )
-
-    elif any(domain in query for domain in ['tiktok.com', 'instagram.com', 'youtube.com', 'youtu.be']):
+    # Detect social media links first
+    if any(domain in query for domain in ['tiktok.com', 'instagram.com']):
         link = query.strip()
-        if 'tiktok.com' in link:
-            label = 'TikTok'
-        elif 'instagram.com' in link:
-            label = 'Instagram'
-        else:
-            label = 'YouTube'
+        label = 'TikTok' if 'tiktok.com' in link else 'Instagram'
 
         key = f"inl_{user_id}_social"
-        user_data[key] = link
+        user_data[key] = {'url': link, 'mode': 'social'}
         cb = CommonParamInline(key=key)
 
-        # Extract metadata for preview thumbnail
         info = bot_func.extract_video_info(link)
         if info:
             preview_title = info.get('title') or f'Download {label} video'
@@ -184,15 +102,97 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
             )
         )
 
+    elif query.strip():
+        # "v query" → YouTube video search, "query" → YouTube audio/MP3
+        if query.startswith('v ') and len(query) > 2:
+            search_text = query[2:].strip()
+            mode = 'video'
+            btn_label = 'Download MP4'
+        else:
+            search_text = query.strip()
+            mode = 'audio'
+            btn_label = 'Download MP3'
+
+        if search_text:
+            logger.info(f'YouTube {mode} search: {search_text}')
+            entries = bot_func.search_youtube(search_text, max_results=5)
+
+            for i, entry in enumerate(entries):
+                title = entry.get('title', 'No title')
+                channel = entry.get('channel', entry.get('uploader', 'Unknown'))
+                duration = entry.get('duration')
+                video_url = entry.get('url') or entry.get('webpage_url', '')
+                video_id = entry.get('id', '')
+                thumbnail = f'https://i.ytimg.com/vi/{video_id}/hqdefault.jpg' if video_id else ''
+
+                key = f"inl_{user_id}_{i}"
+                user_data[key] = {'url': video_url, 'mode': mode}
+
+                duration_str = ''
+                if duration:
+                    mins, secs = divmod(int(duration), 60)
+                    duration_str = f'{mins}:{secs:02d}'
+
+                view_count = entry.get('view_count')
+                views_str = ''
+                if view_count:
+                    if view_count >= 1_000_000:
+                        views_str = f'{view_count / 1_000_000:.1f}M views'
+                    elif view_count >= 1_000:
+                        views_str = f'{view_count / 1_000:.1f}K views'
+                    else:
+                        views_str = f'{view_count} views'
+
+                description_parts = []
+                if duration_str:
+                    description_parts.append(duration_str)
+                if views_str:
+                    description_parts.append(views_str)
+                if channel:
+                    description_parts.append(channel)
+                description = ' | '.join(description_parts) if description_parts else 'YouTube'
+
+                thumb = thumbnail or 'https://placehold.co/320x180.png'
+                cb = CommonParamInline(key=key)
+                articles.append(
+                    InlineQueryResultArticle(
+                        id=str(i),
+                        title=title,
+                        input_message_content=InputTextMessageContent(
+                            message_text=f"{title}\n{video_url}",
+                        ),
+                        description=description,
+                        thumbnail_url=thumb,
+                        reply_markup=InlineKeyboardMarkup(
+                            inline_keyboard=[[InlineKeyboardButton(
+                                text=btn_label,
+                                callback_data=cb.pack(),
+                            )]]
+                        ),
+                    )
+                )
+
+            if not articles:
+                articles.append(
+                    InlineQueryResultArticle(
+                        id='no_results',
+                        title='No results found',
+                        input_message_content=InputTextMessageContent(
+                            message_text='No YouTube results found.',
+                        ),
+                        description=f'No videos found for "{search_text}"',
+                    )
+                )
+
     else:
         articles.append(
             InlineQueryResultArticle(
                 id='help',
                 title='How to use',
                 input_message_content=InputTextMessageContent(
-                    message_text='Use @bot ssoc <query> to search YouTube, or paste a TikTok/Instagram/YouTube link.',
+                    message_text='Type a search query for MP3, "v query" for video, or paste a TikTok/Instagram link.',
                 ),
-                description='ssoc <query> | or paste a social link',
+                description='<query> = MP3 | v <query> = video | TikTok/Insta link',
             )
         )
 

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -124,9 +124,13 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
             label = 'YouTube'
 
         # Extract direct video URL so it sends directly in chat (like @LyBot)
+        logger.info(f'Extracting video info for {label}: {link}')
         info = bot_func.extract_video_info(link)
+        logger.info(f'Extraction result: url={bool(info and info.get("url"))}, title={info.get("title") if info else None}')
+
         if info and info['url']:
             thumb = info['thumbnail'] or 'https://placehold.co/320x180.png'
+            logger.info(f'Using InlineQueryResultVideo: url_len={len(info["url"])}, thumb={thumb[:50]}')
             articles.append(
                 InlineQueryResultVideo(
                     id='dl_social',
@@ -139,7 +143,7 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
                 )
             )
         else:
-            # Fallback to callback button approach if extraction fails
+            logger.warning(f'Extraction failed for {link}, using callback fallback')
             key = f"inl_{user_id}_social"
             user_data[key] = link
             cb = CommonParamInline(key=key)

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -135,14 +135,32 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
         key = f"inl_{user_id}_social"
         user_data[key] = link
         cb = CommonParamInline(key=key)
+
+        # Extract metadata for preview thumbnail
+        info = bot_func.extract_video_info(link)
+        if info:
+            preview_title = info.get('title') or f'Download {label} video'
+            preview_thumb = info.get('thumbnail') or None
+            duration = info.get('duration')
+            desc_parts = [label]
+            if duration:
+                mins, secs = divmod(int(duration), 60)
+                desc_parts.append(f'{mins}:{secs:02d}')
+            preview_desc = ' | '.join(desc_parts)
+        else:
+            preview_title = f'Download {label} video'
+            preview_thumb = None
+            preview_desc = f'Download video from {label}'
+
         articles.append(
             InlineQueryResultArticle(
                 id='dl_social',
-                title=f'Download {label} video',
+                title=preview_title,
                 input_message_content=InputTextMessageContent(
                     message_text=f"Downloading {label} video...\n{link}",
                 ),
-                description=f'Download video from {label}',
+                description=preview_desc,
+                thumbnail_url=preview_thumb,
                 reply_markup=InlineKeyboardMarkup(
                     inline_keyboard=[[InlineKeyboardButton(
                         text="Download",

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -2,7 +2,9 @@ from aiogram import Bot, types, Router
 from aiogram.enums import ParseMode
 from aiogram.types import Message
 from aiogram.types import InlineQueryResultArticle, InputTextMessageContent, InlineKeyboardMarkup, InlineKeyboardButton
+import asyncio
 import html
+import time
 from aiogram.filters.command import Command
 from aiogram.filters.callback_data import CallbackData
 from aiogram.utils.markdown import hide_link
@@ -10,6 +12,9 @@ from src.bot import CommonParamInline
 from src import utils as ut
 import pandas as pd
 from src.Users import Level
+
+# Debounce: store last query time per user
+_last_query_time: dict[int, float] = {}
 
 
 
@@ -57,6 +62,14 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
     query = inline_query.query.strip()
     user_id = inline_query.from_user.id
     logger.trace(f'Inline Query: {query=}')
+
+    # Debounce: wait 1s, skip if user typed more
+    if query:
+        now = time.time()
+        _last_query_time[user_id] = now
+        await asyncio.sleep(1)
+        if _last_query_time.get(user_id) != now:
+            return  # User kept typing, skip this query
 
     articles = []
 

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -1,7 +1,7 @@
 from aiogram import Bot, types, Router
 from aiogram.enums import ParseMode
 from aiogram.types import Message
-from aiogram.types import InlineQueryResultArticle, InlineQueryResultVideo, InputTextMessageContent, InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.types import InlineQueryResultArticle, InputTextMessageContent, InlineKeyboardMarkup, InlineKeyboardButton
 import html
 from aiogram.filters.command import Command
 from aiogram.filters.callback_data import CallbackData
@@ -73,8 +73,11 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
             title = entry.get('title', 'No title')
             channel = entry.get('channel', entry.get('uploader', 'Unknown'))
             duration = entry.get('duration')
-            direct_url = entry.get('url', '')
+            video_url = entry.get('webpage_url') or entry.get('original_url', '')
             thumbnail = entry.get('thumbnail', '')
+
+            key = f"inl_{user_id}_{i}"
+            user_data[key] = video_url
 
             duration_str = ''
             if duration:
@@ -88,19 +91,25 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
                 description_parts.append(channel)
             description = ' | '.join(description_parts) if description_parts else 'YouTube video'
 
-            if direct_url:
-                thumb = thumbnail or 'https://placehold.co/320x180.png'
-                articles.append(
-                    InlineQueryResultVideo(
-                        id=str(i),
-                        video_url=direct_url,
-                        mime_type='video/mp4',
-                        thumbnail_url=thumb,
-                        title=title,
-                        description=description,
-                        video_duration=int(duration) if duration else None,
-                    )
+            thumb = thumbnail or 'https://placehold.co/320x180.png'
+            cb = CommonParamInline(key=key)
+            articles.append(
+                InlineQueryResultArticle(
+                    id=str(i),
+                    title=title,
+                    input_message_content=InputTextMessageContent(
+                        message_text=f"{title}\n{video_url}",
+                    ),
+                    description=description,
+                    thumbnail_url=thumb,
+                    reply_markup=InlineKeyboardMarkup(
+                        inline_keyboard=[[InlineKeyboardButton(
+                            text="Download",
+                            callback_data=cb.pack(),
+                        )]]
+                    ),
                 )
+            )
 
         if not articles:
             articles.append(
@@ -123,46 +132,25 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
         else:
             label = 'YouTube'
 
-        # Extract direct video URL so it sends directly in chat (like @LyBot)
-        logger.info(f'Extracting video info for {label}: {link}')
-        info = bot_func.extract_video_info(link)
-        logger.info(f'Extraction result: url={bool(info and info.get("url"))}, title={info.get("title") if info else None}')
-
-        if info and info['url']:
-            thumb = info['thumbnail'] or 'https://placehold.co/320x180.png'
-            logger.info(f'Using InlineQueryResultVideo: url_len={len(info["url"])}, thumb={thumb[:50]}')
-            articles.append(
-                InlineQueryResultVideo(
-                    id='dl_social',
-                    video_url=info['url'],
-                    mime_type='video/mp4',
-                    thumbnail_url=thumb,
-                    title=info['title'],
-                    description=f'{label} video',
-                    video_duration=int(info['duration']) if info['duration'] else None,
-                )
+        key = f"inl_{user_id}_social"
+        user_data[key] = link
+        cb = CommonParamInline(key=key)
+        articles.append(
+            InlineQueryResultArticle(
+                id='dl_social',
+                title=f'Download {label} video',
+                input_message_content=InputTextMessageContent(
+                    message_text=f"Downloading {label} video...\n{link}",
+                ),
+                description=f'Download video from {label}',
+                reply_markup=InlineKeyboardMarkup(
+                    inline_keyboard=[[InlineKeyboardButton(
+                        text="Download",
+                        callback_data=cb.pack(),
+                    )]]
+                ),
             )
-        else:
-            logger.warning(f'Extraction failed for {link}, using callback fallback')
-            key = f"inl_{user_id}_social"
-            user_data[key] = link
-            cb = CommonParamInline(key=key)
-            articles.append(
-                InlineQueryResultArticle(
-                    id='dl_social',
-                    title=f'Download {label} video',
-                    input_message_content=InputTextMessageContent(
-                        message_text=f"Downloading {label} video...\n{link}",
-                    ),
-                    description=f'Download video from {label}',
-                    reply_markup=InlineKeyboardMarkup(
-                        inline_keyboard=[[InlineKeyboardButton(
-                            text="Download",
-                            callback_data=cb.pack(),
-                        )]]
-                    ),
-                )
-            )
+        )
 
     else:
         articles.append(

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -67,16 +67,14 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
             return
 
         logger.info(f'YouTube search via inline: {search_text}')
-        entries = bot_func.search_youtube(search_text, max_results=5)
+        entries = bot_func.search_youtube(search_text, max_results=3)
 
         for i, entry in enumerate(entries):
             title = entry.get('title', 'No title')
             channel = entry.get('channel', entry.get('uploader', 'Unknown'))
             duration = entry.get('duration')
-            video_url = entry.get('url', '')
-
-            key = f"inl_{user_id}_{i}"
-            user_data[key] = video_url
+            direct_url = entry.get('url', '')
+            thumbnail = entry.get('thumbnail', '')
 
             duration_str = ''
             if duration:
@@ -90,23 +88,19 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
                 description_parts.append(channel)
             description = ' | '.join(description_parts) if description_parts else 'YouTube video'
 
-            cb = CommonParamInline(key=key)
-            articles.append(
-                InlineQueryResultArticle(
-                    id=str(i),
-                    title=title,
-                    input_message_content=InputTextMessageContent(
-                        message_text=f"{title}\n{video_url}",
-                    ),
-                    description=description,
-                    reply_markup=InlineKeyboardMarkup(
-                        inline_keyboard=[[InlineKeyboardButton(
-                            text="Download",
-                            callback_data=cb.pack(),
-                        )]]
-                    ),
+            if direct_url:
+                thumb = thumbnail or 'https://placehold.co/320x180.png'
+                articles.append(
+                    InlineQueryResultVideo(
+                        id=str(i),
+                        video_url=direct_url,
+                        mime_type='video/mp4',
+                        thumbnail_url=thumb,
+                        title=title,
+                        description=description,
+                        video_duration=int(duration) if duration else None,
+                    )
                 )
-            )
 
         if not articles:
             articles.append(

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -1,7 +1,7 @@
 from aiogram import Bot, types, Router
 from aiogram.enums import ParseMode
 from aiogram.types import Message
-from aiogram.types import InlineQueryResultArticle, InputTextMessageContent, InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.types import InlineQueryResultArticle, InlineQueryResultVideo, InputTextMessageContent, InlineKeyboardMarkup, InlineKeyboardButton
 import html
 from aiogram.filters.command import Command
 from aiogram.filters.callback_data import CallbackData
@@ -129,26 +129,42 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
         else:
             label = 'YouTube'
 
-        key = f"inl_{user_id}_social"
-        user_data[key] = link
-        cb = CommonParamInline(key=key)
-
-        articles.append(
-            InlineQueryResultArticle(
-                id='dl_social',
-                title=f'Download {label} video',
-                input_message_content=InputTextMessageContent(
-                    message_text=f"Downloading {label} video...\n{link}",
-                ),
-                description=f'Download video from {label}',
-                reply_markup=InlineKeyboardMarkup(
-                    inline_keyboard=[[InlineKeyboardButton(
-                        text="Download",
-                        callback_data=cb.pack(),
-                    )]]
-                ),
+        # Extract direct video URL so it sends directly in chat (like @LyBot)
+        info = bot_func.extract_video_info(link)
+        if info and info['url']:
+            thumb = info['thumbnail'] or 'https://placehold.co/320x180.png'
+            articles.append(
+                InlineQueryResultVideo(
+                    id='dl_social',
+                    video_url=info['url'],
+                    mime_type='video/mp4',
+                    thumbnail_url=thumb,
+                    title=info['title'],
+                    description=f'{label} video',
+                    video_duration=int(info['duration']) if info['duration'] else None,
+                )
             )
-        )
+        else:
+            # Fallback to callback button approach if extraction fails
+            key = f"inl_{user_id}_social"
+            user_data[key] = link
+            cb = CommonParamInline(key=key)
+            articles.append(
+                InlineQueryResultArticle(
+                    id='dl_social',
+                    title=f'Download {label} video',
+                    input_message_content=InputTextMessageContent(
+                        message_text=f"Downloading {label} video...\n{link}",
+                    ),
+                    description=f'Download video from {label}',
+                    reply_markup=InlineKeyboardMarkup(
+                        inline_keyboard=[[InlineKeyboardButton(
+                            text="Download",
+                            callback_data=cb.pack(),
+                        )]]
+                    ),
+                )
+            )
 
     else:
         articles.append(

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -6,47 +6,15 @@ import asyncio
 import html
 import time
 from aiogram.filters.command import Command
-from aiogram.filters.callback_data import CallbackData
 from aiogram.utils.markdown import hide_link
 from src.bot import CommonParamInline
 from src import utils as ut
 import pandas as pd
 from src.Users import Level
 
-# Debounce: store last query time per user
 _last_query_time: dict[int, float] = {}
 
-
-
-class CommonParamTick(CallbackData, prefix="tick"):
-    # id: str
-    title: str
-    vid_data: str
-
 router = Router()
-# router.message.middleware(SharedContextMiddleware())
-
-
-# @router.inline_query()
-# async def inline_query_handler(inline_query: types.InlineQuery, logger):
-#     logger.trace('Inline  MOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOD')
-#     article = InlineQueryResultArticle(
-#         id=uuid4().hex,
-#         title="Check my profile",
-#         input_message_content=InputTextMessageContent(message_text="Check my profile by button bellow:"),
-#         article = InlineQueryResultArticle(
-#             id=uuid4().hex,
-#             title="Check my profile",
-#             input_message_content=InputTextMessageContent(message_text="Check my profile by button bellow:"),
-#             reply_markup=InlineKeyboardMarkup(
-#                 inline_keyboard=[[
-#                     InlineKeyboardButton(text="text")
-#                 ]]
-#             )
-#         )
-#     )
-#     await inline_query.answer(results=[article])
-#     ...
 
 async def check_access(message: types.Message, allowed_levels: list[Level]):
     user_bot = message.from_user
@@ -57,41 +25,58 @@ async def check_access(message: types.Message, allowed_levels: list[Level]):
         return None
     return user
 
+def _fmt_duration(secs):
+    if not secs:
+        return ''
+    m, s = divmod(int(secs), 60)
+    return f'{m}:{s:02d}'
+
+
+def _fmt_views(count):
+    if not count:
+        return ''
+    if count >= 1_000_000:
+        return f'{count / 1_000_000:.1f}M views'
+    if count >= 1_000:
+        return f'{count / 1_000:.1f}K views'
+    return f'{count} views'
+
+
 @router.inline_query()
 async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func, user_data):
     query = inline_query.query.strip()
     user_id = inline_query.from_user.id
     logger.trace(f'Inline Query: {query=}')
 
-    # Debounce: wait 1s, skip if user typed more
     if query:
         now = time.time()
         _last_query_time[user_id] = now
         await asyncio.sleep(1)
         if _last_query_time.get(user_id) != now:
-            return  # User kept typing, skip this query
+            return
+        # Bound the debounce dict
+        if len(_last_query_time) > 1000:
+            cutoff = now - 300
+            for uid in [k for k, v in _last_query_time.items() if v < cutoff]:
+                _last_query_time.pop(uid, None)
 
     articles = []
 
-    # Detect social media links first
     if any(domain in query for domain in ['tiktok.com', 'instagram.com']):
-        link = query.strip()
+        link = query
         label = 'TikTok' if 'tiktok.com' in link else 'Instagram'
 
         key = f"inl_{user_id}_social"
-        user_data[key] = {'url': link, 'mode': 'social'}
+        user_data[key] = {'url': link, 'mode': 'social', 'title': ''}
         cb = CommonParamInline(key=key)
 
-        info = bot_func.extract_video_info(link)
+        info = await asyncio.to_thread(bot_func.extract_video_info, link)
         if info:
             preview_title = info.get('title') or f'Download {label} video'
             preview_thumb = info.get('thumbnail') or None
-            duration = info.get('duration')
-            desc_parts = [label]
-            if duration:
-                mins, secs = divmod(int(duration), 60)
-                desc_parts.append(f'{mins}:{secs:02d}')
-            preview_desc = ' | '.join(desc_parts)
+            duration_str = _fmt_duration(info.get('duration'))
+            preview_desc = f'{label} | {duration_str}' if duration_str else label
+            user_data[key]['title'] = info.get('title', '')
         else:
             preview_title = f'Download {label} video'
             preview_thumb = None
@@ -115,57 +100,37 @@ async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func
             )
         )
 
-    elif query.strip():
-        # "v query" → YouTube video search, "query" → YouTube audio/MP3
+    elif query:
         if query.startswith('v ') and len(query) > 2:
             search_text = query[2:].strip()
             mode = 'video'
             btn_label = 'Download MP4'
         else:
-            search_text = query.strip()
+            search_text = query
             mode = 'audio'
             btn_label = 'Download MP3'
 
         if search_text:
             logger.info(f'YouTube {mode} search: {search_text}')
-            entries = bot_func.search_youtube(search_text, max_results=5)
+            entries = await asyncio.to_thread(bot_func.search_youtube, search_text, 5)
 
             for i, entry in enumerate(entries):
                 title = entry.get('title', 'No title')
-                channel = entry.get('channel', entry.get('uploader', 'Unknown'))
-                duration = entry.get('duration')
+                channel = entry.get('channel') or entry.get('uploader', '')
                 video_url = entry.get('url') or entry.get('webpage_url', '')
                 video_id = entry.get('id', '')
-                thumbnail = f'https://i.ytimg.com/vi/{video_id}/hqdefault.jpg' if video_id else ''
+                thumb = f'https://i.ytimg.com/vi/{video_id}/hqdefault.jpg' if video_id else 'https://placehold.co/320x180.png'
 
                 key = f"inl_{user_id}_{i}"
                 user_data[key] = {'url': video_url, 'mode': mode, 'title': title}
 
-                duration_str = ''
-                if duration:
-                    mins, secs = divmod(int(duration), 60)
-                    duration_str = f'{mins}:{secs:02d}'
+                parts = [p for p in (
+                    _fmt_duration(entry.get('duration')),
+                    _fmt_views(entry.get('view_count')),
+                    channel,
+                ) if p]
+                description = ' | '.join(parts) if parts else 'YouTube'
 
-                view_count = entry.get('view_count')
-                views_str = ''
-                if view_count:
-                    if view_count >= 1_000_000:
-                        views_str = f'{view_count / 1_000_000:.1f}M views'
-                    elif view_count >= 1_000:
-                        views_str = f'{view_count / 1_000:.1f}K views'
-                    else:
-                        views_str = f'{view_count} views'
-
-                description_parts = []
-                if duration_str:
-                    description_parts.append(duration_str)
-                if views_str:
-                    description_parts.append(views_str)
-                if channel:
-                    description_parts.append(channel)
-                description = ' | '.join(description_parts) if description_parts else 'YouTube'
-
-                thumb = thumbnail or 'https://placehold.co/320x180.png'
                 cb = CommonParamInline(key=key)
                 articles.append(
                     InlineQueryResultArticle(

--- a/main.py
+++ b/main.py
@@ -6,26 +6,20 @@ import asyncio
 from dotenv import load_dotenv
 import pandas as pd
 import loguru
-from pprint import pprint
 
 from src.Users import UserTele
 from src.bot import Bot_Func
 from src import utils as ut
 import jinja2
 
-from aiogram import F, Bot, Dispatcher, types, Router
+from aiogram import Bot, Dispatcher, types
 from aiogram.filters.command import Command
-from aiogram.types import InlineQuery, InlineQueryResultArticle, InputTextMessageContent
 from aiogram.types.user import User as TgUser
 from src.MiddleWare import SharedContextMiddleware
 from handlers import test_bot, media_bot, voice_stt
 
 # from aiogram.filters import Text
 
-from src.Users import UserTele
-from src.bot import Bot_Func
-from src import utils as ut
-from src.bot import CommonParamYouTube
 
 import glob
 
@@ -66,14 +60,14 @@ async def start_user(message:types.Message):
         all_df = pd.concat([users_reg_df, df])   #.reset_index(drop=True)
         ut.save_reg_user(all_df)
         logger.debug(f'Add new user {usr.id} {ut.get_name_from_pydantic(usr)}')
-        await message.answer(f'Все готово. Гарного користування!')
+        await message.answer('Все готово. Гарного користування!')
     else:
         await message.answer(f'Скучали за тобою {usr.id}')
         return 
 
 
-@dp.message(lambda msg: msg.text and any(link in msg.text for link in ['youtu.be', 'youtube.com']))
-async def cmd_numbers(message: types.Message, cfg):
+@dp.message(lambda msg: msg.text and not msg.via_bot and any(link in msg.text for link in ['youtu.be', 'youtube.com']))
+async def cmd_numbers(message: types.Message):
     user_bot = message.from_user
     link = ut.expand_url(message.text)
     link = link.split('&list')[0]
@@ -81,7 +75,7 @@ async def cmd_numbers(message: types.Message, cfg):
     df_t = ut.get_user_by_id(user_bot.id)
 
     if df_t.empty:
-        await message.reply(f"Ти не зареганий натисни /start")
+        await message.reply("Ти не зареганий натисни /start")
         return
     user = ut.pandas2pydentic(df_t)
     available_memory = user.level.value - user.use_memory
@@ -89,54 +83,7 @@ async def cmd_numbers(message: types.Message, cfg):
 
     if available_memory < 0:
         await message.reply(f"Ви використали свій ліміт({ut.h_readable(user.level.value)})"+
-                             f" на цей місяць, підніміть свій статус")
-        return
-
-    # If the message came via inline bot, auto-download best quality
-    if message.via_bot:
-        logger.info(f'Inline YouTube download for {user.id}: {link}')
-        environment = jinja2.Environment()
-        answer_template = environment.from_string(
-            "@{{bot_name}}\n\nУ тебе лишилося {{avail_mem}}\n\n{{progress_bar_str_value}}\n\n{{url}}"
-        )
-
-        current_date = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        loc_video = f"media/{user.id}/{current_date}"
-        ydl_opts = {
-            'format': 'bestvideo+bestaudio/best',
-            'outtmpl': loc_video,
-        }
-
-        res = await bot_func.get_dwn_media(ydl_opts, message, youtubeLink=link)
-        if not res:
-            await message.answer('Не вдалося завантажити. Перевір посилання і спробуй ще раз.')
-            logger.warning(f'Failed to download inline YouTube video {link}\n\n\n')
-            return
-        loc_video, file_size = res
-
-        available_memory -= file_size
-        total_mem_user_level = user.level.value
-        used_memory_per_user = user.use_memory
-
-        answer_cap = answer_template.render(
-            bot_name=cfg.shared_vars.bot_name,
-            avail_mem=ut.h_readable(available_memory),
-            progress_bar_str_value=ut.progress_bar_str(used_memory_per_user, total_mem_user_level),
-            url=link,
-        )
-
-        try:
-            await message.answer_video(
-                video=types.FSInputFile(loc_video), caption=answer_cap
-            )
-        except Exception as e:
-            await message.reply(f"An error occurred while sending the video: {e}")
-        user.use_memory += file_size
-        loc_match = glob.glob(os.path.join('.', f'{loc_video}*'))
-        assert loc_match
-        loc_video = loc_match[0]
-        ut.update_row(user)
-        ut.delete_video_file(loc_video)
+                             " на цей місяць, підніміть свій статус")
         return
 
     wait_bot_msg = await message.reply(f"Твоя лінка на youtube повідомлення опрацьовується!\
@@ -163,7 +110,7 @@ async def cmd_numbers(message: types.Message, cfg):
 
 
 
-@dp.message(lambda msg: msg.text and any(soc in msg.text for soc in ['instagram.com', 'tiktok.com']))
+@dp.message(lambda msg: msg.text and not msg.via_bot and any(soc in msg.text for soc in ['instagram.com', 'tiktok.com']))
 async def handle_inst_tick(message: types.Message, cfg):
     user_bot = message.from_user
     df_t = ut.get_user_by_id(user_bot.id)
@@ -174,7 +121,7 @@ async def handle_inst_tick(message: types.Message, cfg):
         "@{{bot_name}}\n\nУ тебе лишилося {{avail_mem}}\n\n{{progress_bar_str_value}}\n\n{{url}}"
     )
     if df_t.empty:
-        await message.reply(f"Ти не зареганий натисни /start")
+        await message.reply("Ти не зареганий натисни /start")
         return
     
     user = ut.pandas2pydentic(df_t)
@@ -183,7 +130,7 @@ async def handle_inst_tick(message: types.Message, cfg):
     if availMemory < 0:
         await message.reply(
             f"Ви використали свій ліміт({ut.h_readable(user.level.value)}) на цей місяць,"+
-              f"підніміть свій статус"
+              "підніміть свій статус"
             )
         return
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pyyaml==6.0.2
 tomli==2.0.1
 tqdm==4.67.1
 yt-dlp==2025.3.27
+curl_cffi>=0.7.0
 easydict==1.13
 srtools==0.1.13
 Jinja2==3.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ yt-dlp==2025.3.27
 easydict==1.13
 srtools==0.1.13
 Jinja2==3.1.6
+ruff==0.11.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pyyaml==6.0.2
 tomli==2.0.1
 tqdm==4.67.1
 yt-dlp==2025.3.27
-curl_cffi>=0.7.0
+curl_cffi==0.10.0
 easydict==1.13
 srtools==0.1.13
 Jinja2==3.1.6

--- a/src/bot.py
+++ b/src/bot.py
@@ -3,8 +3,9 @@ from src import utils as ut
 import glob
 import yt_dlp
 import os
+import asyncio
+import time
 from aiogram.filters.callback_data import CallbackData
-# import aiogram.filters.callback_data.CallbackData
 
 from aiogram import types
 
@@ -85,23 +86,54 @@ class Bot_Func:
 
 
 
-    # TODO: remove from main
     async def get_dwn_media(self, ydl_opts, user_msg, youtubeLink=''):
         med_url = youtubeLink if youtubeLink else user_msg.text
 
         loc_video = ydl_opts['outtmpl']
 
         try:
-            # TODO: make async not now
-            # TODO: add captions not now
-            # logger.debug(f'Start download video {loc_video}') 
-            strt_dwn_msg = await user_msg.answer("Start downloading ...")
-            self.log.debug(f'Start download video {loc_video}') 
-            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-                ydl.download([med_url])
-                # self.log.trace(f'{info=}')
+            strt_dwn_msg = await user_msg.answer("Downloading... 0%\n⬜⬜⬜⬜⬜⬜⬜⬜")
+            self.log.debug(f'Start download video {loc_video}')
+
+            loop = asyncio.get_event_loop()
+            last_update = [0.0]
+
+            def progress_hook(d):
+                if d['status'] != 'downloading':
+                    return
+                now = time.time()
+                if now - last_update[0] < 2:
+                    return
+                last_update[0] = now
+
+                total = d.get('total_bytes') or d.get('total_bytes_estimate', 0)
+                downloaded = d.get('downloaded_bytes', 0)
+                if total <= 0:
+                    return
+
+                pct = downloaded / total * 100
+                filled = int(8 * downloaded // total)
+                bar = '🟩' * filled + '⬜' * (8 - filled)
+                speed = d.get('speed', 0)
+                speed_str = f" | {speed / 1024 / 1024:.1f} MB/s" if speed else ""
+                text = f"Downloading... {pct:.0f}%\n{bar}{speed_str}"
+
+                fut = asyncio.run_coroutine_threadsafe(
+                    strt_dwn_msg.edit_text(text), loop
+                )
+                try:
+                    fut.result(timeout=5)
+                except Exception:
+                    pass
+
+            ydl_opts_with_hook = {**ydl_opts, 'progress_hooks': [progress_hook]}
+
+            def download():
+                with yt_dlp.YoutubeDL(ydl_opts_with_hook) as ydl:
+                    ydl.download([med_url])
+
+            await asyncio.to_thread(download)
             await strt_dwn_msg.delete()
-            # await message.edit_caption(caption="✅ Download successful!")
             self.log.success(f"✅ Download successful! {loc_video}")
         except yt_dlp.utils.DownloadError as e:
             self.log.error(f"❌ Download error: {e}")

--- a/src/bot.py
+++ b/src/bot.py
@@ -63,12 +63,11 @@ class Bot_Func:
             self.log.error(f"Video info extraction error: {e}")
             return None
 
-    def search_youtube(self, query, max_results=5):
-        """Search YouTube using yt-dlp and return up to max_results entries."""
+    def search_youtube(self, query, max_results=3):
+        """Search YouTube and return entries with direct video URLs."""
         ydl_opts = {
             'quiet': True,
-            'extract_flat': True,
-            'force_generic_extractor': False,
+            'format': 'best',
         }
         try:
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:

--- a/src/bot.py
+++ b/src/bot.py
@@ -46,14 +46,18 @@ class Bot_Func:
     def extract_video_info(self, url):
         """Extract direct video URL and metadata without downloading."""
         ydl_opts = {
-            'quiet': True,
-            'format': 'best',  # single combined stream for direct URL
+            'quiet': False,
+            'format': 'best',
         }
         try:
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 info = ydl.extract_info(url, download=False)
+                direct_url = info.get('url', '')
+                self.log.info(f'extract_video_info: title={info.get("title")}, '
+                              f'has_url={bool(direct_url)}, url_len={len(direct_url)}, '
+                              f'ext={info.get("ext")}, format={info.get("format")}')
                 return {
-                    'url': info.get('url', ''),
+                    'url': direct_url,
                     'thumbnail': info.get('thumbnail', ''),
                     'title': info.get('title', 'Video'),
                     'duration': info.get('duration', 0),

--- a/src/bot.py
+++ b/src/bot.py
@@ -45,40 +45,24 @@ class Bot_Func:
         self.root_prj = root_prj
 
     def extract_video_info(self, url):
-        """Extract direct video URL and metadata without downloading."""
-        ydl_opts = {
-            'quiet': True,
-            'format': 'best',
-        }
+        """Extract video metadata (title, thumbnail, duration). Blocking."""
         try:
-            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+            with yt_dlp.YoutubeDL({'quiet': True, 'skip_download': True}) as ydl:
                 info = ydl.extract_info(url, download=False)
-                direct_url = info.get('url', '')
-                self.log.info(f'extract_video_info: title={info.get("title")}, '
-                              f'has_url={bool(direct_url)}, url_len={len(direct_url)}, '
-                              f'ext={info.get("ext")}, format={info.get("format")}')
                 return {
-                    'url': direct_url,
                     'thumbnail': info.get('thumbnail', ''),
                     'title': info.get('title', 'Video'),
                     'duration': info.get('duration', 0),
-                    'filesize': info.get('filesize') or info.get('filesize_approx') or 0,
                 }
         except Exception as e:
             self.log.error(f"Video info extraction error: {e}")
             return None
 
     def search_youtube(self, query, max_results=3):
-        """Search YouTube and return entries with video metadata."""
-        ydl_opts = {
-            'quiet': True,
-            'extract_flat': True,
-        }
+        """Search YouTube via ytsearch. Blocking."""
         try:
-            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-                result = ydl.extract_info(
-                    f"ytsearch{max_results}:{query}", download=False
-                )
+            with yt_dlp.YoutubeDL({'quiet': True, 'extract_flat': True}) as ydl:
+                result = ydl.extract_info(f"ytsearch{max_results}:{query}", download=False)
                 return result.get('entries', [])
         except Exception as e:
             self.log.error(f"YouTube search error: {e}")

--- a/src/bot.py
+++ b/src/bot.py
@@ -95,8 +95,14 @@ class Bot_Func:
             strt_dwn_msg = await user_msg.answer("Downloading... 0%\n⬜⬜⬜⬜⬜⬜⬜⬜")
             self.log.debug(f'Start download video {loc_video}')
 
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             last_update = [0.0]
+
+            async def _edit_progress(text):
+                try:
+                    await strt_dwn_msg.edit_text(text)
+                except Exception:
+                    pass
 
             def progress_hook(d):
                 if d['status'] != 'downloading':
@@ -118,11 +124,10 @@ class Bot_Func:
                 speed_str = f" | {speed / 1024 / 1024:.1f} MB/s" if speed else ""
                 text = f"Downloading... {pct:.0f}%\n{bar}{speed_str}"
 
-                fut = asyncio.run_coroutine_threadsafe(
-                    strt_dwn_msg.edit_text(text), loop
-                )
                 try:
-                    fut.result(timeout=5)
+                    asyncio.run_coroutine_threadsafe(
+                        _edit_progress(text), loop
+                    )
                 except Exception:
                     pass
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -3,9 +3,6 @@ from src import utils as ut
 import glob
 import yt_dlp
 import os
-import json
-from pprint import pprint
-import aiogram
 from aiogram.filters.callback_data import CallbackData
 # import aiogram.filters.callback_data.CallbackData
 
@@ -31,6 +28,10 @@ class CommonParamYouTube(CallbackData, prefix="vid"):
     # id: str
     title: str
     vid_data: str
+
+
+class CommonParamInline(CallbackData, prefix="idl"):
+    key: str
 
 
 
@@ -125,7 +126,7 @@ class Bot_Func:
 
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             try:
-                self.log.info(f'Скачується формати відео  .....')
+                self.log.info('Скачується формати відео  .....')
                 info_dict = ydl.extract_info(video_url, download=False)
                 video_name = info_dict['title']
                 self.log.info(f'Скачали формати відео з назвою {video_name}')
@@ -146,7 +147,7 @@ class Bot_Func:
     def get_keyboard(self, link):
         try:
             yt_info = self._list_formats(link)
-        except Exception as e:
+        except Exception:
             self.log.error('Failed to download youtube format')
             return
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -46,7 +46,7 @@ class Bot_Func:
     def extract_video_info(self, url):
         """Extract direct video URL and metadata without downloading."""
         ydl_opts = {
-            'quiet': False,
+            'quiet': True,
             'format': 'best',
         }
         try:
@@ -68,10 +68,10 @@ class Bot_Func:
             return None
 
     def search_youtube(self, query, max_results=3):
-        """Search YouTube and return entries with direct video URLs."""
+        """Search YouTube and return entries with video metadata."""
         ydl_opts = {
             'quiet': True,
-            'format': 'best',
+            'extract_flat': True,
         }
         try:
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:

--- a/src/bot.py
+++ b/src/bot.py
@@ -43,6 +43,26 @@ class Bot_Func:
         self.log = log
         self.root_prj = root_prj
 
+    def extract_video_info(self, url):
+        """Extract direct video URL and metadata without downloading."""
+        ydl_opts = {
+            'quiet': True,
+            'format': 'best',  # single combined stream for direct URL
+        }
+        try:
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                info = ydl.extract_info(url, download=False)
+                return {
+                    'url': info.get('url', ''),
+                    'thumbnail': info.get('thumbnail', ''),
+                    'title': info.get('title', 'Video'),
+                    'duration': info.get('duration', 0),
+                    'filesize': info.get('filesize') or info.get('filesize_approx') or 0,
+                }
+        except Exception as e:
+            self.log.error(f"Video info extraction error: {e}")
+            return None
+
     def search_youtube(self, query, max_results=5):
         """Search YouTube using yt-dlp and return up to max_results entries."""
         ydl_opts = {


### PR DESCRIPTION
## Summary
- Inline results now use **callback buttons** with a download handler (`idl` prefix) instead of relying on message handlers that don't fire for inline-posted messages
- Added `CommonParamInline` CallbackData class — stores URL in `user_data` dict, passes short key via callback
- New `handle_inline_download` callback handler in `media_bot.py` handles the full download flow (user check, memory tracking, yt-dlp download, send video, cleanup)
- Direct message handlers (`cmd_numbers`, `handle_inst_tick`) now skip `via_bot` messages to avoid double-processing
- Added `ruff` to `requirements.txt`

## Test plan
- [ ] Test `@bot ssoc <query>` — select a video, click Download button, verify video is sent
- [ ] Test `@bot <tiktok_url>` — select result, click Download, verify video is sent
- [ ] Test `@bot <instagram_url>` — same flow
- [ ] Test `@bot <youtube_url>` — same flow
- [ ] Test direct YouTube link in DM — should still show format selection keyboard
- [ ] Test direct TikTok link in DM — should still auto-download
- [ ] Verify memory tracking works correctly after inline download

🤖 Generated with [Claude Code](https://claude.com/claude-code)