### PR TITLE
fix: robust video format detection in media handler

### DIFF
--- a/handlers/media_bot.py
+++ b/handlers/media_bot.py
@@ -78,8 +78,8 @@ async def handle_callback(callback_query: types.CallbackQuery, logger, user_data
         youtube_url = youtube_url,
         name = title)
     try:
-        #HACK: delete later
-        if loc_media.endswith('mp4'):
+        ext = os.path.splitext(loc_media)[1].lower()
+        if ext in ('.mp4', '.mkv', '.webm'):
             logger.info(f'Sending as video: {loc_media}')
             await bot_msg.answer_video(
                                         video=types.FSInputFile(loc_media),


### PR DESCRIPTION
## Summary

- Replace `loc_media.endswith('mp4')` with `os.path.splitext` + explicit extension set
- Now correctly sends `.mkv` and `.webm` files as video (not audio)
- Also removes the stale `#HACK: delete later` comment

## Test plan

- [ ] Download a YouTube video in mp4 format — should send as video
- [ ] Download a YouTube video that yt-dlp saves as `.webm` — should send as video (previously sent as audio)
- [ ] Download audio-only format — should still send as audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)