### PR TITLE
fix: stream claude output in queue-watch (--output-format stream-json)

### DIFF
--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -393,3 +393,62 @@ async def cmd_review(message: types.Message, logger):
         f'Файл: {filename}\n'
         f'Результат зʼявиться на GitHub за кілька хвилин.'
     )
+
+
+@router.message(Command('check_pr'))
+async def cmd_check_pr(message: types.Message, logger):
+    caller = message.from_user
+    logger.info(f'/check_pr called by {caller.id} ({caller.full_name}): {message.text!r}')
+
+    user = await check_access(message, [Level.admin, Level.vip])
+    if not user:
+        return
+
+    args = message.text.split()
+    if len(args) != 2 or not args[1].isdigit() or int(args[1]) <= 0:
+        logger.warning(f'/check_pr bad args: {args}')
+        await message.reply('Формат: /check_pr <pr_number>')
+        return
+    pr_number = int(args[1])
+
+    today = datetime.now(timezone.utc).date()
+    queue_root = REVIEW_QUEUE_DIR.parent
+    records = []
+    for subdir in ('pending', 'processed'):
+        d = queue_root / subdir
+        if not d.exists():
+            continue
+        for f in sorted(d.glob('*.json')):
+            try:
+                data = json.loads(f.read_text())
+            except Exception:
+                continue
+            if data.get('pr_number') != pr_number or data.get('caller_id') != caller.id:
+                continue
+            rq_str = str(data.get('requested_at', '')).replace('Z', '+00:00')
+            try:
+                rq_dt = datetime.fromisoformat(rq_str)
+            except ValueError:
+                continue
+            if rq_dt.astimezone(timezone.utc).date() != today:
+                continue
+            records.append((subdir, data))
+
+    if not records:
+        await message.reply(f'Нема записів для PR #{pr_number} сьогодні від тебе.')
+        return
+
+    records.sort(key=lambda r: r[1].get('requested_at', ''))
+    icons = {'success': '✅', 'failed': '❌'}
+    lines = [f'📋 PR #{pr_number} сьогодні ({caller.full_name}) — {len(records)} запис(ів):', '']
+    for i, (state, data) in enumerate(records, 1):
+        status = data.get('status', state)
+        icon = icons.get(status, '⏳' if state == 'pending' else '⌛')
+        line = f'{i}. {icon} {status} | req={data.get("requested_at", "?")}'
+        if data.get('completed_at'):
+            line += f' | done={data["completed_at"]}'
+        if 'exit_code' in data:
+            line += f' | rc={data["exit_code"]}'
+        lines.append(line)
+
+    await message.reply('\n'.join(lines))

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -6,7 +6,7 @@ import asyncio
 import html
 import json
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from aiogram.filters.command import Command
 from aiogram.utils.markdown import hide_link
@@ -353,7 +353,7 @@ async def cmd_show_users_mb(message: types.Message, logger, cfg):
 
 
 @router.message(Command('review'))
-async def cmd_review(message: types.Message, logger, bot: Bot):
+async def cmd_review(message: types.Message, logger):
     caller = message.from_user
     logger.info(f'/review called by {caller.id} ({caller.full_name}): {message.text!r}')
 
@@ -368,7 +368,7 @@ async def cmd_review(message: types.Message, logger, bot: Bot):
         return
     pr_number = int(args[1])
 
-    now = datetime.now()
+    now = datetime.now(timezone.utc)
     payload = {
         'pr_number': pr_number,
         'caller_id': caller.id,
@@ -387,7 +387,7 @@ async def cmd_review(message: types.Message, logger, bot: Bot):
         await message.reply('❌ Не вдалося записати запит у чергу. Перевір логи.')
         return
 
-    logger.info(f'/review queued: {request_file}')
+    logger.info(f'/review queued payload={payload} file={request_file}')
     await message.reply(
         f'✅ Запит на review PR #{pr_number} поставлено в чергу.\n'
         f'Файл: {filename}\n'

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -4,13 +4,18 @@ from aiogram.types import Message
 from aiogram.types import InlineQueryResultArticle, InputTextMessageContent, InlineKeyboardMarkup, InlineKeyboardButton
 import asyncio
 import html
+import json
 import time
+from datetime import datetime
+from pathlib import Path
 from aiogram.filters.command import Command
 from aiogram.utils.markdown import hide_link
 from src.bot import CommonParamInline
 from src import utils as ut
 import pandas as pd
 from src.Users import Level
+
+REVIEW_QUEUE_DIR = Path('/tmp/tele-bot-review-queue/pending')
 
 _last_query_time: dict[int, float] = {}
 
@@ -361,49 +366,30 @@ async def cmd_review(message: types.Message, logger, bot: Bot):
         logger.warning(f'/review bad args: {args}')
         await message.reply('Формат: /review <pr_number>')
         return
-    pr_number = args[1]
-    session_name = f'review-pr-{pr_number}'
+    pr_number = int(args[1])
 
-    logger.info(f'/review spawning `just review {pr_number}` for {caller.id}')
-    await message.reply(f'🔍 Запускаю review для PR #{pr_number}...')
+    now = datetime.now()
+    payload = {
+        'pr_number': pr_number,
+        'caller_id': caller.id,
+        'caller_username': caller.username,
+        'caller_full_name': caller.full_name,
+        'requested_at': now.isoformat(timespec='seconds'),
+    }
+    filename = f'pr-{pr_number}-{now.strftime("%Y%m%dT%H%M%S")}-{caller.id}.json'
+    request_file = REVIEW_QUEUE_DIR / filename
 
     try:
-        proc = await asyncio.create_subprocess_exec(
-            'just', 'review', pr_number,
-            cwd=str(ut.root_prj),
-            stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        await asyncio.wait_for(proc.wait(), timeout=15)
-    except asyncio.TimeoutError:
-        logger.warning(f'/review spawn timed out for PR #{pr_number}')
-        await message.reply('⚠️ Запуск тайм-аут. Перевір tmux сесію вручну на сервері.')
-        return
-    except FileNotFoundError:
-        logger.exception('/review `just` not found in PATH')
-        await message.reply('❌ `just` не знайдено в PATH сервера.')
-        return
+        REVIEW_QUEUE_DIR.mkdir(parents=True, exist_ok=True)
+        request_file.write_text(json.dumps(payload, ensure_ascii=False))
     except Exception:
-        logger.exception(f'/review failed to spawn just review {pr_number}')
-        await message.reply('❌ Не вдалося запустити review. Перевір логи сервера.')
+        logger.exception(f'/review failed to write queue file {request_file}')
+        await message.reply('❌ Не вдалося записати запит у чергу. Перевір логи.')
         return
 
-    check = await asyncio.create_subprocess_exec(
-        'tmux', 'has-session', '-t', session_name,
-        stdout=asyncio.subprocess.DEVNULL,
-        stderr=asyncio.subprocess.DEVNULL,
-    )
-    await check.wait()
-    if check.returncode != 0:
-        logger.warning(f'/review tmux session `{session_name}` not running after spawn')
-        await message.reply(
-            f'⚠️ Сесія `{session_name}` не створилась. Перевір логи сервера.'
-        )
-        return
-
-    logger.info(f'/review tmux session `{session_name}` started for PR #{pr_number}')
+    logger.info(f'/review queued: {request_file}')
     await message.reply(
-        f'✅ Review для PR #{pr_number} запущено в tmux (`{session_name}`).\n'
-        f'Результат зʼявиться на GitHub через кілька хвилин.'
+        f'✅ Запит на review PR #{pr_number} поставлено в чергу.\n'
+        f'Файл: {filename}\n'
+        f'Результат зʼявиться на GitHub за кілька хвилин.'
     )

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -362,7 +362,7 @@ async def cmd_review(message: types.Message, logger):
         return
 
     args = message.text.split()
-    if len(args) != 2 or not args[1].isdigit():
+    if len(args) != 2 or not args[1].isdigit() or int(args[1]) <= 0:
         logger.warning(f'/review bad args: {args}')
         await message.reply('Формат: /review <pr_number>')
         return

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -345,3 +345,65 @@ async def cmd_show_users_mb(message: types.Message, logger, cfg):
     except Exception as e:
         logger.exception(f"Проблема при зчитуванні користувачів: {e}")
         await message.reply("❌ Виникла помилка при зчитуванні таблиці користувачів.")
+
+
+@router.message(Command('review'))
+async def cmd_review(message: types.Message, logger, bot: Bot):
+    caller = message.from_user
+    logger.info(f'/review called by {caller.id} ({caller.full_name}): {message.text!r}')
+
+    user = await check_access(message, [Level.admin, Level.vip])
+    if not user:
+        return
+
+    args = message.text.split()
+    if len(args) != 2 or not args[1].isdigit():
+        logger.warning(f'/review bad args: {args}')
+        await message.reply('Формат: /review <pr_number>')
+        return
+    pr_number = args[1]
+    session_name = f'review-pr-{pr_number}'
+
+    logger.info(f'/review spawning `just review {pr_number}` for {caller.id}')
+    await message.reply(f'🔍 Запускаю review для PR #{pr_number}...')
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            'just', 'review', pr_number,
+            cwd=str(ut.root_prj),
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.wait(), timeout=15)
+    except asyncio.TimeoutError:
+        logger.warning(f'/review spawn timed out for PR #{pr_number}')
+        await message.reply('⚠️ Запуск тайм-аут. Перевір tmux сесію вручну на сервері.')
+        return
+    except FileNotFoundError:
+        logger.exception('/review `just` not found in PATH')
+        await message.reply('❌ `just` не знайдено в PATH сервера.')
+        return
+    except Exception:
+        logger.exception(f'/review failed to spawn just review {pr_number}')
+        await message.reply('❌ Не вдалося запустити review. Перевір логи сервера.')
+        return
+
+    check = await asyncio.create_subprocess_exec(
+        'tmux', 'has-session', '-t', session_name,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    await check.wait()
+    if check.returncode != 0:
+        logger.warning(f'/review tmux session `{session_name}` not running after spawn')
+        await message.reply(
+            f'⚠️ Сесія `{session_name}` не створилась. Перевір логи сервера.'
+        )
+        return
+
+    logger.info(f'/review tmux session `{session_name}` started for PR #{pr_number}')
+    await message.reply(
+        f'✅ Review для PR #{pr_number} запущено в tmux (`{session_name}`).\n'
+        f'Результат зʼявиться на GitHub через кілька хвилин.'
+    )

--- a/justfile
+++ b/justfile
@@ -28,7 +28,7 @@ fmt-check:
 lint-file file:
     ruff check --select E9,F63,F7,F82 {{file}}
 
-# Run full CI check locally (lint + import check)
+# Run full CI check locally (ruff does syntax + lint in one pass)
 ci:
     #!/usr/bin/env bash
     echo "=== Ruff: blocking errors ==="
@@ -36,23 +36,6 @@ ci:
     echo ""
     echo "=== Ruff: all warnings ==="
     ruff check . || true
-    echo ""
-    echo "=== Import check ==="
-    python3 -c "
-import ast, sys, pathlib
-errors = []
-for p in pathlib.Path('.').rglob('*.py'):
-    if any(part in p.parts for part in ['.venv', '__pycache__', '.git']):
-        continue
-    try:
-        ast.parse(p.read_text())
-    except SyntaxError as e:
-        errors.append(f'{p}:{e}')
-if errors:
-    print('\\n'.join(errors)); sys.exit(1)
-else:
-    print('✅ All modules parse OK')
-"
 
 # Review a PR with Ukrainian beginner-friendly review
 # Usage:

--- a/justfile
+++ b/justfile
@@ -117,6 +117,9 @@ queue-watch:
         echo "[$(date +'%F %T')] 🚀 spawning tmux session '$s' (attach: tmux attach -t $s)"
 
         # Tee claude output to $log so diagnosis works even if scrollback is lost.
+        # --verbose makes claude print each agent turn (tool uses, thinking, etc).
+        # A background heartbeat keeps the session alive-looking during long pauses.
+        # awk prefixes every line with a timestamp so you see progress in real time.
         if tmux new-session -d -s "$s" \
             "exec > >(tee -a '$log') 2>&1; \
              echo '=== $(date +%FT%T) /review-pr-ukr $pr (requested by $caller id=$caller_id) ==='; \
@@ -124,9 +127,11 @@ queue-watch:
              echo 'claude --version:'; claude --version 2>/dev/null || true; \
              echo 'PWD:' \$(pwd); \
              echo; \
-             echo '──── claude output ────'; \
-             claude --print '/review-pr-ukr $pr'; \
-             rc=\$?; \
+             echo '──── claude output (verbose) ────'; \
+             ( while sleep 20; do echo \"[\$(date +'%F %T')] ⏳ still working...\"; done ) & HB=\$!; \
+             claude --verbose --print '/review-pr-ukr $pr' 2>&1 | awk '{ print strftime(\"[%F %T]\"), \$0; fflush() }'; \
+             rc=\${PIPESTATUS[0]}; \
+             kill \$HB 2>/dev/null; wait \$HB 2>/dev/null; \
              echo; echo \"──── claude exit=\$rc ────\"; \
              echo '✅ Done. Session closes in 10 min...'; \
              sleep 600"

--- a/justfile
+++ b/justfile
@@ -120,6 +120,8 @@ queue-watch:
         # --verbose makes claude print each agent turn (tool uses, thinking, etc).
         # A background heartbeat keeps the session alive-looking during long pauses.
         # awk prefixes every line with a timestamp so you see progress in real time.
+        # When claude exits, jq stamps completion info into the processed JSON.
+        local pfile="$processed/$base"
         if tmux new-session -d -s "$s" \
             "exec > >(tee -a '$log') 2>&1; \
              echo '=== $(date +%FT%T) /review-pr-ukr $pr (requested by $caller id=$caller_id) ==='; \
@@ -133,6 +135,11 @@ queue-watch:
              rc=\${PIPESTATUS[0]}; \
              kill \$HB 2>/dev/null; wait \$HB 2>/dev/null; \
              echo; echo \"──── claude exit=\$rc ────\"; \
+             jq --arg ts \"\$(date -u +%FT%TZ)\" --argjson rc \$rc --arg log '$log' \
+                '. + {completed_at: \$ts, exit_code: \$rc, status: (if \$rc == 0 then \"success\" else \"failed\" end), log_file: \$log}' \
+                '$pfile' > '$pfile.tmp' && mv '$pfile.tmp' '$pfile' \
+                && echo \"📋 status written to $pfile\" \
+                || echo \"⚠️  failed to update $pfile\"; \
              echo '✅ Done. Session closes in 10 min...'; \
              sleep 600"
         then

--- a/justfile
+++ b/justfile
@@ -53,6 +53,11 @@ review pr:
         tmux attach-session -t "$session"
     fi
 
+
+review_watcher:
+  #!/usr/bin/env bash
+  tmux new-session -d -s review-queue 'just queue-watch'
+
 # Watch /tmp/tele-bot-review-queue/pending/ for review requests from the bot.
 # The bot's /review handler writes JSON files there with caller info + PR number.
 # This watcher picks each up and spawns `claude --print '/review-pr-ukr N'` in tmux.
@@ -129,11 +134,11 @@ queue-watch:
              echo 'claude --version:'; claude --version 2>/dev/null || true; \
              echo 'PWD:' \$(pwd); \
              echo; \
-             echo '──── claude output (verbose) ────'; \
-             ( while sleep 20; do echo \"[\$(date +'%F %T')] ⏳ still working...\"; done ) & HB=\$!; \
-             claude --verbose --print '/review-pr-ukr $pr' 2>&1 | awk '{ print strftime(\"[%F %T]\"), \$0; fflush() }'; \
+             echo '──── claude output ────'; \
+             claude --output-format stream-json '/review-pr-ukr $pr' 2>&1 \
+               | jq -r --unbuffered 'if .type == \"assistant\" then (.message.content[] | select(.type == \"text\") | .text) elif .type == \"result\" then \"\\n✅ Done (exit=\\(.subtype))\" else empty end' 2>/dev/null \
+               | awk '{ print strftime(\"[%F %T]\"), \$0; fflush() }'; \
              rc=\${PIPESTATUS[0]}; \
-             kill \$HB 2>/dev/null; wait \$HB 2>/dev/null; \
              echo; echo \"──── claude exit=\$rc ────\"; \
              jq --arg ts \"\$(date -u +%FT%TZ)\" --argjson rc \$rc --arg log '$log' \
                 '. + {completed_at: \$ts, exit_code: \$rc, status: (if \$rc == 0 then \"success\" else \"failed\" end), log_file: \$log}' \

--- a/justfile
+++ b/justfile
@@ -89,11 +89,24 @@ queue-watch:
         fi
         echo "[$(date +'%F %T')] ▶  pr=$pr caller=$caller requested=$ts"
         local s="review-pr-$pr"
+        local logdir="/tmp/tele-bot-review-queue/logs"
+        local log="$logdir/pr-$pr-$(date +%Y%m%dT%H%M%S).log"
+        mkdir -p "$logdir"
         tmux kill-session -t "$s" 2>/dev/null || true
+        # Output from claude is tee'd to $log so we can diagnose later even if
+        # the tmux scrollback is lost. Exit code of claude is preserved.
         if tmux new-session -d -s "$s" \
-            "claude --print '/review-pr-ukr $pr'; echo; echo '✅ Done. Session closes in 10 min...'; sleep 600"
+            "exec > >(tee -a '$log') 2>&1; \
+             echo '=== $(date +%FT%T) /review-pr-ukr $pr ==='; \
+             echo 'which claude:'; which claude || echo '  (not in PATH)'; \
+             echo; \
+             claude --print '/review-pr-ukr $pr'; \
+             rc=\$?; \
+             echo; echo \"=== claude exit=\$rc ===\"; \
+             echo '✅ Session closes in 10 min...'; \
+             sleep 600"
         then
-            echo "[$(date +'%F %T')] ✅ tmux session '$s' started"
+            echo "[$(date +'%F %T')] ✅ tmux session '$s' started, log=$log"
         else
             echo "[$(date +'%F %T')] ❌ failed to start tmux session '$s'"
         fi

--- a/justfile
+++ b/justfile
@@ -69,3 +69,58 @@ review pr:
     else
         tmux attach-session -t "$session"
     fi
+
+# Watch /tmp/tele-bot-review-queue/pending/ for review requests from the bot.
+# The bot's /review handler writes JSON files there with caller info + PR number.
+# This watcher picks each up and spawns `claude --print '/review-pr-ukr N'` in tmux.
+#
+# Deps:   brew install entr jq   (already installed? `which entr jq`)
+# Run:    tmux new-session -d -s review-queue 'just queue-watch'
+# Attach: tmux attach -t review-queue
+# Stop:   tmux kill-session -t review-queue
+#
+# JSON file format (written by the bot):
+#   { "pr_number": 51, "caller_id": 12345, "caller_full_name": "Mike",
+#     "requested_at": "2026-04-16T23:05:00" }
+queue-watch:
+    #!/usr/bin/env bash
+    set -u
+    pending="/tmp/tele-bot-review-queue/pending"
+    processed="/tmp/tele-bot-review-queue/processed"
+    mkdir -p "$pending" "$processed"
+    chmod 1777 "$pending" "$processed" 2>/dev/null || true
+    touch "$pending/.keep"
+
+    process_file() {
+        local file="$1"
+        [[ "$file" != *.json ]] && return 0
+        [[ ! -f "$file" ]] && return 0
+        local pr caller ts
+        pr=$(jq -r '.pr_number // empty' "$file" 2>/dev/null)
+        caller=$(jq -r '.caller_full_name // "unknown"' "$file" 2>/dev/null)
+        ts=$(jq -r '.requested_at // "?"' "$file" 2>/dev/null)
+        if [[ ! "$pr" =~ ^[0-9]+$ ]]; then
+            echo "[$(date +'%F %T')] ⚠️  SKIP bad pr in $(basename "$file")"
+            mv "$file" "$processed/bad-$(basename "$file")"
+            return 0
+        fi
+        echo "[$(date +'%F %T')] ▶  pr=$pr caller=$caller requested=$ts"
+        local s="review-pr-$pr"
+        tmux kill-session -t "$s" 2>/dev/null || true
+        if tmux new-session -d -s "$s" \
+            "claude --print '/review-pr-ukr $pr'; echo; echo '✅ Done. Session closes in 10 min...'; sleep 600"
+        then
+            echo "[$(date +'%F %T')] ✅ tmux session '$s' started"
+        else
+            echo "[$(date +'%F %T')] ❌ failed to start tmux session '$s'"
+        fi
+        mv "$file" "$processed/$(basename "$file")"
+    }
+
+    echo "[$(date +'%F %T')] 🛰  queue-watch started ($pending)"
+    while true; do
+        for f in "$pending"/*.json; do
+            [[ -e "$f" ]] && process_file "$f"
+        done
+        echo "$pending/.keep" | entr -d -n -z true 2>/dev/null || true
+    done

--- a/justfile
+++ b/justfile
@@ -78,39 +78,65 @@ queue-watch:
         local file="$1"
         [[ "$file" != *.json ]] && return 0
         [[ ! -f "$file" ]] && return 0
-        local pr caller ts
+
+        local base pr caller caller_id ts
+        base=$(basename "$file")
+        echo "──────────────────────────────────────────"
+        echo "[$(date +'%F %T')] 📨 picking up $base"
+        echo "[$(date +'%F %T')] 📄 content:"
+        jq . "$file" 2>/dev/null | sed 's/^/     /' || echo "     (invalid JSON)"
+
         pr=$(jq -r '.pr_number // empty' "$file" 2>/dev/null)
         caller=$(jq -r '.caller_full_name // "unknown"' "$file" 2>/dev/null)
+        caller_id=$(jq -r '.caller_id // "?"' "$file" 2>/dev/null)
         ts=$(jq -r '.requested_at // "?"' "$file" 2>/dev/null)
+
         if [[ ! "$pr" =~ ^[0-9]+$ ]]; then
-            echo "[$(date +'%F %T')] ⚠️  SKIP bad pr in $(basename "$file")"
-            mv "$file" "$processed/bad-$(basename "$file")"
+            echo "[$(date +'%F %T')] ⚠️  SKIP: pr_number=$pr is not a positive integer"
+            mv "$file" "$processed/bad-$base"
+            echo "[$(date +'%F %T')] 🗂  moved → processed/bad-$base"
             return 0
         fi
-        echo "[$(date +'%F %T')] ▶  pr=$pr caller=$caller requested=$ts"
+
+        echo "[$(date +'%F %T')] ▶  pr=$pr caller=$caller(id=$caller_id) requested=$ts"
         local s="review-pr-$pr"
+
+        # Dedup: if a review for this PR is already running, DO NOT kill it —
+        # keep the request file for retry (queue it back).
+        if tmux has-session -t "$s" 2>/dev/null; then
+            echo "[$(date +'%F %T')] ⏳ session '$s' already running — requeuing $base for later"
+            local stamp=$(date +%s)
+            mv "$file" "$pending/$stamp-$base"
+            return 0
+        fi
+
         local logdir="/tmp/tele-bot-review-queue/logs"
         local log="$logdir/pr-$pr-$(date +%Y%m%dT%H%M%S).log"
         mkdir -p "$logdir"
-        tmux kill-session -t "$s" 2>/dev/null || true
-        # Output from claude is tee'd to $log so we can diagnose later even if
-        # the tmux scrollback is lost. Exit code of claude is preserved.
+        echo "[$(date +'%F %T')] 📝 log → $log"
+        echo "[$(date +'%F %T')] 🚀 spawning tmux session '$s' (attach: tmux attach -t $s)"
+
+        # Tee claude output to $log so diagnosis works even if scrollback is lost.
         if tmux new-session -d -s "$s" \
             "exec > >(tee -a '$log') 2>&1; \
-             echo '=== $(date +%FT%T) /review-pr-ukr $pr ==='; \
-             echo 'which claude:'; which claude || echo '  (not in PATH)'; \
+             echo '=== $(date +%FT%T) /review-pr-ukr $pr (requested by $caller id=$caller_id) ==='; \
+             echo 'which claude:'; which claude || echo '  ❌ claude NOT in PATH'; \
+             echo 'claude --version:'; claude --version 2>/dev/null || true; \
+             echo 'PWD:' \$(pwd); \
              echo; \
+             echo '──── claude output ────'; \
              claude --print '/review-pr-ukr $pr'; \
              rc=\$?; \
-             echo; echo \"=== claude exit=\$rc ===\"; \
-             echo '✅ Session closes in 10 min...'; \
+             echo; echo \"──── claude exit=\$rc ────\"; \
+             echo '✅ Done. Session closes in 10 min...'; \
              sleep 600"
         then
-            echo "[$(date +'%F %T')] ✅ tmux session '$s' started, log=$log"
+            echo "[$(date +'%F %T')] ✅ tmux session '$s' started"
+            mv "$file" "$processed/$base"
+            echo "[$(date +'%F %T')] 🗂  moved → processed/$base"
         else
-            echo "[$(date +'%F %T')] ❌ failed to start tmux session '$s'"
+            echo "[$(date +'%F %T')] ❌ failed to start tmux session '$s' — keeping $base for retry"
         fi
-        mv "$file" "$processed/$(basename "$file")"
     }
 
     echo "[$(date +'%F %T')] 🛰  queue-watch started ($pending)"


### PR DESCRIPTION
## Summary

- `--print` buffers all claude output until the process exits — the tmux log shows only heartbeat `⏳ still working...` for 10-20 min with no visibility into what claude is doing
- Replace with `--output-format stream-json` which streams each assistant turn as a JSON event immediately
- `jq --unbuffered` extracts the text content and result status in real time
- `awk` adds timestamps to each line as before
- Removed the heartbeat background process (no longer needed — real output is visible immediately)

## Before
```
[14:24:07] ⏳ still working...
[14:24:27] ⏳ still working...
... (10+ minutes of silence)
```

## After
```
[14:24:07] Gathering context for PR #52...
[14:24:09] Running gh pr diff 52...
[14:24:12] ## Review: 🔄 Request Changes
...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)