### PR TITLE
fix: handle 0-byte reg_user.csv in get_reg_users()

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -156,7 +156,11 @@ def get_reg_users() -> pd.DataFrame:
     reg_user_path.parent.mkdir(parents=True, exist_ok=True)
 
     if reg_user_path.is_file():
-        df = pd.read_csv(reg_user_path)
+        try:
+            df = pd.read_csv(reg_user_path)
+        except pd.errors.EmptyDataError:
+            logger.warning("Csv file has no header (0-byte file)")
+            return create_empty_csv()
         if df.empty:
             logger.warning("Csv file is empty")
             return create_empty_csv()


### PR DESCRIPTION
## Summary

- A 0-byte `data/reg_user.csv` makes `pd.read_csv` raise `pandas.errors.EmptyDataError: No columns to parse from file` *before* the existing `if df.empty` check runs.
- Every aiogram handler that calls `get_reg_users()` / `get_user_by_id()` (e.g. `handle_inst_tick`, `cmd_numbers`, `/start`) crashes on each update with that exception — visible in the user-reported traceback at `main.py:134` → `src/utils.py:154`.
- The existing `df.empty` branch only catches CSVs that have a header line but zero rows. A truly empty (0-byte / no-header) file blows up earlier.
- Fix: catch `pd.errors.EmptyDataError` and fall back to `create_empty_csv()`, mirroring the existing missing-file branch.

## Root cause

`src/utils.py:153-169` `get_reg_users()`:

```python
if reg_user_path.is_file():
    df = pd.read_csv(reg_user_path)   # raises on 0-byte file
    if df.empty:                       # unreachable for 0-byte file
        ...
```

## Repro / verification

```python
Path('reg_user.csv').touch()           # 0-byte file
pd.read_csv('reg_user.csv')
# → pandas.errors.EmptyDataError: No columns to parse from file
```

After the fix:
- 0-byte file → falls back to `create_empty_csv()` (writes a fresh header-only CSV)
- header-only CSV → existing `df.empty` branch still handles it
- CSV with data → unchanged

## Test plan

- [x] Reproduced `EmptyDataError` against a 0-byte CSV with the unpatched code path
- [x] Verified the patched `try / except pd.errors.EmptyDataError` path returns a fresh empty DataFrame instead of crashing
- [x] `ruff check src/utils.py` passes
- [ ] Deploy to the Pi and confirm `/start` + a YouTube/Instagram link no longer raise after deleting `data/reg_user.csv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)