### PR TITLE
Add error handling in csv defs

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -11,6 +11,7 @@ from functools import reduce
 import numpy as np
 import re
 from src.Users import UserTele, Level
+from scr.Errors import CSVError
 
 root_prj = Path(__file__).parent.parent.absolute()
 
@@ -129,13 +130,15 @@ def remove_non_ascii(text: str) -> str:
 def get_user_by_id(usr_id: int) -> pd.DataFrame:
     users_reg_df: pd.DataFrame  = get_reg_users()
 
-    if usr_id in users_reg_df.index:
-        logger.debug(f'User {usr_id} is already registered ')
-        return users_reg_df.loc[[usr_id]]
-    else:
-        logger.debug(f'User {usr_id} not in db')
-        return pd.DataFrame()
-
+    try:
+        if usr_id in users_reg_df.index:
+            logger.debug(f'User {usr_id} is already registered ')
+            return users_reg_df.loc[[usr_id]]
+        else:
+            logger.debug(f'User {usr_id} not in db')
+            return pd.DataFrame()
+    except TypeError:
+        raise CSVError('Wrongy input type')
 
 def update_row(user:UserTele) -> None:
     all_df = get_reg_users()
@@ -151,17 +154,16 @@ def get_reg_users() -> pd.DataFrame:
     reg_user_path.parent.mkdir(parents=True, exist_ok=True)
 
     if reg_user_path.is_file():
-        df = pd.read_csv(reg_user_path)
-        if df.empty:     
-            logger.warning('Csv file is empty')
+        try:
+            df = pd.read_csv(reg_user_path)
+            if 'id' not in df.columns:
+                raise CSVError('Column id does not exist in CSV')
+            df.set_index('id', inplace=True)
+            return df
+        except FileNotFoundError:
             return create_empty_csv()
-        
-        df= df.replace({np.nan: None})
-        df.set_index('id', inplace=True)
-        return df
-    else:
-        logger.warning('not exist')
-        return create_empty_csv()
+        except pd.errors.ParserError as e:
+            raise CSVError(f'CSV file is corupted: {e}')
         
     # STEP_1: check if file exist
     # if 
@@ -171,8 +173,12 @@ def get_reg_users() -> pd.DataFrame:
 
 
 def save_reg_user(df: pd.DataFrame) -> None:
-    reg_user_path = root_prj / 'data/reg_user.csv'
-    df.to_csv(reg_user_path)
+    if df:
+        reg_user_path = root_prj / 'data/reg_user.csv'
+        try:
+            df.to_csv(reg_user_path)
+        except Exception:
+            raise CSVError(f'{Exception}')
 
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -159,11 +159,10 @@ def get_reg_users() -> pd.DataFrame:
         logger.warning('CSV does not exist — creating empty one')
         return create_empty_csv()
     
-    if reg_user_path.is_file():
-        try:
-            df = pd.read_csv(reg_user_path)
-        except pd.errors.ParserError as e:
-            raise CSVError(f'CSV file is corrupted: {e}')
+    try:
+        df = pd.read_csv(reg_user_path)
+    except pd.errors.ParserError as e:
+        raise CSVError(f'CSV file is corrupted: {e}')
         
     if df.empty or 'id' not in df.columns:
         logger.warning('CSV is empty or missing id column — recreating')
@@ -172,11 +171,7 @@ def get_reg_users() -> pd.DataFrame:
     df = df.replace({np.nan: None})
     df.set_index('id', inplace=True)
     return df
-    # STEP_1: check if file exist
-    # if 
-    # STEP_2: if not create empty file and return empyy dataframe
-    # STEP3: if exist, read csv dile and return DataFrame
-    ...
+
 
 
 def save_reg_user(df: pd.DataFrame) -> None:

--- a/src/utils.py
+++ b/src/utils.py
@@ -11,7 +11,7 @@ from functools import reduce
 import numpy as np
 import re
 from src.Users import UserTele, Level
-from scr.Errors import CSVError
+from src.Errors import CSVError
 
 root_prj = Path(__file__).parent.parent.absolute()
 
@@ -128,20 +128,22 @@ def remove_non_ascii(text: str) -> str:
     return re.sub(r'[^\x00-\x7F]+', '', text)
 
 def get_user_by_id(usr_id: int) -> pd.DataFrame:
+    if not isinstance(usr_id, int):
+        raise CSVError(f'usr_id must be int, got {type(usr_id).__name__}')
     users_reg_df: pd.DataFrame  = get_reg_users()
+    
+    if usr_id in users_reg_df.index:
+        logger.debug(f'User {usr_id} is already registered ')
+        return users_reg_df.loc[[usr_id]]
+    else:
+        logger.debug(f'User {usr_id} not in db')
+        return pd.DataFrame()
 
-    try:
-        if usr_id in users_reg_df.index:
-            logger.debug(f'User {usr_id} is already registered ')
-            return users_reg_df.loc[[usr_id]]
-        else:
-            logger.debug(f'User {usr_id} not in db')
-            return pd.DataFrame()
-    except TypeError:
-        raise CSVError('Wrongy input type')
 
 def update_row(user:UserTele) -> None:
     all_df = get_reg_users()
+    if user.id not in all_df.index:
+        raise CSVError(f'User {user.id} not found in CSV')
     user_row = pydantic2pandas(user)
     logger.trace(f'{all_df=}, \n{user_row=}')
     all_df.update(user_row)
@@ -153,18 +155,23 @@ def get_reg_users() -> pd.DataFrame:
     print(f'{reg_user_path.parent=}')
     reg_user_path.parent.mkdir(parents=True, exist_ok=True)
 
+    if not reg_user_path.is_file():
+        logger.warning('CSV does not exist — creating empty one')
+        return create_empty_csv()
+    
     if reg_user_path.is_file():
         try:
             df = pd.read_csv(reg_user_path)
-            if 'id' not in df.columns:
-                raise CSVError('Column id does not exist in CSV')
-            df.set_index('id', inplace=True)
-            return df
-        except FileNotFoundError:
-            return create_empty_csv()
         except pd.errors.ParserError as e:
-            raise CSVError(f'CSV file is corupted: {e}')
+            raise CSVError(f'CSV file is corrupted: {e}')
         
+    if df.empty or 'id' not in df.columns:
+        logger.warning('CSV is empty or missing id column — recreating')
+        return create_empty_csv()
+
+    df = df.replace({np.nan: None})
+    df.set_index('id', inplace=True)
+    return df
     # STEP_1: check if file exist
     # if 
     # STEP_2: if not create empty file and return empyy dataframe
@@ -173,12 +180,14 @@ def get_reg_users() -> pd.DataFrame:
 
 
 def save_reg_user(df: pd.DataFrame) -> None:
-    if df:
-        reg_user_path = root_prj / 'data/reg_user.csv'
-        try:
-            df.to_csv(reg_user_path)
-        except Exception:
-            raise CSVError(f'{Exception}')
+    if df is None:
+        logger.warning('save_reg_user got None - skipping')
+        return
+    reg_user_path = root_prj / 'data/reg_user.csv'
+    try:
+        df.to_csv(reg_user_path)
+    except Exception as e:
+        raise CSVError(f'Failed to save CSV: {e}') from e
 
 
 


### PR DESCRIPTION
What I did:

get_reg_users():
Add a try-except around pd.read_csv() — if the file is corrupted, log an error and create a new empty CSV
Check that the 'id' column exists before set_index
Use CSVError from src/Errors.py (it already exists but is not used anywhere!)

save_reg_user(df):
Add a check that df is not None
Wrap to_csv() in try-except (disk may be full)

update_row(user):
What if a user with such an id does not exist? Add a check

get_user_by_id(usr_id):
What if usr_id is not a number? Add type validation