### PR TITLE
TikTok: стійке завантаження (retry, no-audio recovery, діагностика) + злиття dev↔master

### DIFF
--- a/handlers/media_bot.py
+++ b/handlers/media_bot.py
@@ -118,9 +118,8 @@ async def handle_callback(callback_query: types.CallbackQuery, logger, user_data
         ut.update_row(user)
     except Exception as e:
         await bot_msg.reply(f"An error occurred while sending the video: {e}")
-    
-    
-    ut.delete_video_file(loc_media)
+    finally:
+        ut.delete_video_file(loc_media)
     
 
 

--- a/handlers/media_bot.py
+++ b/handlers/media_bot.py
@@ -93,7 +93,9 @@ async def handle_callback(
         # 'outtmpl': '%(title)s.%(ext)s'
     }
 
-    res = await bot_func.get_dwn_media(ydl_opts, bot_msg, youtubeLink=youtube_url)
+    res = await bot_func.get_dwn_media(
+        ydl_opts, bot_msg, youtubeLink=youtube_url, user_id=user_bot.id
+    )
     if not res:
         await bot_msg.answer(
             "Не вдалося завантажити. Перевір посилання і спробуй ще раз."
@@ -185,7 +187,9 @@ async def handle_inline_download(
     loc_media = f"media/{user_id}/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.%(ext)s"
     ydl_opts = {**_YDL_OPTS_BY_MODE[mode], "outtmpl": loc_media}
 
-    res = await bot_func.get_dwn_media(ydl_opts, status_msg, youtubeLink=url)
+    res = await bot_func.get_dwn_media(
+        ydl_opts, status_msg, youtubeLink=url, user_id=user_id
+    )
     await status_msg.delete()
     if not res:
         await bot.send_message(

--- a/handlers/media_bot.py
+++ b/handlers/media_bot.py
@@ -182,7 +182,7 @@ async def handle_inline_download(
 
     status_msg = await bot.send_message(user_id, "Start downloading ...")
 
-    loc_media = f"media/{user_id}/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
+    loc_media = f"media/{user_id}/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.%(ext)s"
     ydl_opts = {**_YDL_OPTS_BY_MODE[mode], "outtmpl": loc_media}
 
     res = await bot_func.get_dwn_media(ydl_opts, status_msg, youtubeLink=url)

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -371,16 +371,16 @@ async def cmd_setlevel(message: types.Message, logger, bot: Bot):
             return
         
         target_id = int(args[1])
-        target_level_name = args[2]
+        level_name = args[2]
 
-        if target_level_name not in Level.__members__:
+        if level_name not in Level.__members__:
             levels = ', '.join(Level.__members__)
             logger.warning('Unknown level.')
             await message.reply(f'❌ Невідомий рівень. Доступні рівні: {levels}')
             return
         
-        new_level = Level[target_level_name]
-        target_df = ut.get_user_by_id(target_id) 
+        new_level = Level[level_name]
+        target_df = ut.get_user_by_id(target_id)
 
         if target_df.empty:
             logger.warning('Target user is empty')
@@ -393,7 +393,7 @@ async def cmd_setlevel(message: types.Message, logger, bot: Bot):
         target_user.level = new_level
         ut.update_row(target_user)
         try:
-            await bot.send_message(target_id, f'Твій новий level: {target_user.level.name}.')
+            await bot.send_message(target_id, f'Твій новий рівень: {target_user.level.name}.')
         except Exception:
             logger.warning(f'Невдалось повідомити користувача про зміну рівня{target_id}.')
         await message.reply(f'✅ Рівень користувача {target_user.full_name} змінено на {target_user.level.name}')

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -363,7 +363,7 @@ async def cmd_setlevel(message: types.Message, logger, bot: Bot):
             await message.reply("❌ user_id має бути числом")
             return
 
-        target_new_level = args[2] \
+        target_new_level = args[2] 
         
         target_df=ut.get_user_by_id(target_id)
 
@@ -388,4 +388,6 @@ async def cmd_setlevel(message: types.Message, logger, bot: Bot):
     except Exception as e:
         logger.exception(f"Проблема в /setlevel: {e}")
         await message.reply("❌ Виникла несподівана помилка")
+
+
     

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -30,6 +30,7 @@ async def check_access(message: types.Message, allowed_levels: list[Level]):
         return None
     return user
 
+
 def _fmt_duration(secs):
     if not secs:
         return ''
@@ -364,32 +365,35 @@ async def cmd_setlevel(message: types.Message, logger, bot: Bot):
             logger.warning(f'args leghth doesn\'t equal 3. len(args)= {len(args)}')
             await message.reply('Формат: /setlevel <user_id> <user_new_level>')
             return
+        if not args[1].isdigit():
+            logger.warning(f'user_id is not int')
+            await message.reply("❌ user_id має бути числом")
+            return
         
-        target_id = int(args[1]) 
-        target_new_level = args[2] 
-        target_df=ut.get_user_by_id(target_id)
+        target_id = int(args[1])
+        target_new_level = args[2]
+
+        if target_new_level not in Level.__members__:
+            levels = ', '.join(Level.__members__)
+            logger.warning(f'Unknown level.')
+            await message.reply(f'❌ Невідомий рівень. Доступні рівні: {levels}')
+            return
+        
+        new_level = Level[target_new_level]
+        target_df = ut.get_user_by_id(target_id) 
 
         if target_df.empty:
                 logger.warning('Target user is empty')
                 await message.reply('Незнайдено вказаного користувача')
                 return
         
-        target_user=ut.pandas2pydentic(target_df)
-        new_level = Level[target_new_level]
-        
+        target_user = ut.pandas2pydentic(target_df)
+        old_level = target_user.level
+        logger.info(f'/setlevel {target_id} ({target_user.full_name}): {old_level.name} -> {new_level.name}')
         target_user.level = new_level
         ut.update_row(target_user)
         await bot.send_message(target_id, f'Твій новий level: {target_user.level.name}.')
         await message.reply(f'✅ Рівень користувача {target_user.full_name} змінено на {target_user.level.name}')
-    except ValueError as e:
-            logger.warning(f'user_id is not int. {e}')
-            await message.reply("❌ user_id має бути числом")
-            return
-    except KeyError as e:
-            levels = ', '.join(l.name for l in Level)
-            logger.warning(f'Unknown level. {e}')
-            await message.reply(f'❌ Невідомий рівень. Доступні рівні: {levels}')
-            return
     except Exception as e:
         logger.exception(f"Проблема в /setlevel: {e}")
         await message.reply("❌ Виникла несподівана помилка")

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -353,41 +353,37 @@ async def cmd_setlevel(message: types.Message, logger, bot: Bot):
         return
     
     try:
-        try:
-            args = message.text.split()
-            if len(args) != 3:
-                await message.reply('Формат: /setlevel <user_id> <user_new_level>')
-                return
-            target_id = int(args[1]) 
-        except ValueError:
-            await message.reply("❌ user_id має бути числом")
+        args = message.text.split()
+        if len(args) != 3:
+            logger.warning(f'args leghth doesn\'t equal 3. len(args)= {len(args)}')
+            await message.reply('Формат: /setlevel <user_id> <user_new_level>')
             return
-
-        target_new_level = args[2] 
         
+        target_id = int(args[1]) 
+        target_new_level = args[2] 
         target_df=ut.get_user_by_id(target_id)
 
         if target_df.empty:
+                logger.warning('Target user is empty')
                 await message.reply('Незнайдено вказаного користувача')
                 return
         
         target_user=ut.pandas2pydentic(target_df)
-
-        try:
-            new_level = Level[target_new_level]
-        except KeyError:
-            levels = ', '.join(l.name for l in Level)
-            await message.reply(f'❌ Невідомий рівень. Доступні рівні: {levels}')
-            return
+        new_level = Level[target_new_level]
         
         target_user.level = new_level
         ut.update_row(target_user)
         await bot.send_message(target_id, f'Твій новий level: {target_user.level.name}.')
         await message.reply(f'✅ Рівень користувача {target_user.full_name} змінено на {target_user.level.name}')
-
+    except ValueError as e:
+            logger.warning(f'user_id is not int. {e}')
+            await message.reply("❌ user_id має бути числом")
+            return
+    except KeyError as e:
+            levels = ', '.join(l.name for l in Level)
+            logger.warning(f'Unknown level. {e}')
+            await message.reply(f'❌ Невідомий рівень. Доступні рівні: {levels}')
+            return
     except Exception as e:
         logger.exception(f"Проблема в /setlevel: {e}")
         await message.reply("❌ Виникла несподівана помилка")
-
-
-    

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -357,15 +357,14 @@ async def cmd_setlevel(message: types.Message, logger, bot: Bot):
             args = message.text.split()
             if len(args) != 3:
                 await message.reply('Формат: /setlevel <user_id> <user_new_level>')
-                levels = ', '.join(l.name for l in Level)
-                await message.reply(f'Доступні рівні: {levels}')
                 return
             target_id = int(args[1]) 
         except ValueError:
             await message.reply("❌ user_id має бути числом")
             return
 
-        target_new_level = args[2]
+        target_new_level = args[2] \
+        
         target_df=ut.get_user_by_id(target_id)
 
         if target_df.empty:
@@ -373,7 +372,15 @@ async def cmd_setlevel(message: types.Message, logger, bot: Bot):
                 return
         
         target_user=ut.pandas2pydentic(target_df)
-        target_user.level = Level[target_new_level]
+
+        try:
+            new_level = Level[target_new_level]
+        except KeyError:
+            levels = ', '.join(l.name for l in Level)
+            await message.reply(f'❌ Невідомий рівень. Доступні рівні: {levels}')
+            return
+        
+        target_user.level = new_level
         ut.update_row(target_user)
         await bot.send_message(target_id, f'Твій новий level: {target_user.level}.')
         await message.reply(f'✅ Рівень користувача {target_user.full_name} змінено на {target_user.level.name}')

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -347,7 +347,7 @@ async def cmd_show_users_mb(message: types.Message, logger, cfg):
         await message.reply("❌ Виникла помилка при зчитуванні таблиці користувачів.")
 
 @router.message(Command('setlevel'))
-async def cmd_setlevel(message: types.Message, logger, cfg, bot: Bot):
+async def cmd_setlevel(message: types.Message, logger, bot: Bot):
     user = await check_access(message, [Level.admin])
     if not user:
         return
@@ -363,18 +363,20 @@ async def cmd_setlevel(message: types.Message, logger, cfg, bot: Bot):
             target_id = int(args[1]) 
         except ValueError:
             await message.reply("❌ user_id має бути числом")
+            return
 
         target_new_level = args[2]
         target_df=ut.get_user_by_id(target_id)
-        target_user=ut.pandas2pydentic(target_df)
 
         if target_df.empty:
                 await message.reply('Незнайдено вказаного користувача')
                 return
         
+        target_user=ut.pandas2pydentic(target_df)
         target_user.level = Level[target_new_level]
         ut.update_row(target_user)
         await bot.send_message(target_id, f'Твій новий level: {target_user.level}.')
+        await message.reply(f'✅ Рівень користувача {target_user.full_name} змінено на {target_user.level.name}')
 
     except Exception as e:
         logger.exception(f"Проблема в /setlevel: {e}")

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -357,6 +357,7 @@ async def cmd_show_users_mb(message: types.Message, logger, cfg):
 async def cmd_setlevel(message: types.Message, logger, bot: Bot):
     user = await check_access(message, [Level.admin])
     if not user:
+        logger.warning('user levele is not admin')
         return
     
     try:

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -362,30 +362,30 @@ async def cmd_setlevel(message: types.Message, logger, bot: Bot):
     try:
         args = message.text.split()
         if len(args) != 3:
-            logger.warning(f'args leghth doesn\'t equal 3. len(args)= {len(args)}')
+            logger.warning(f'args length doesn\'t equal 3. len(args)= {len(args)}')
             await message.reply('Формат: /setlevel <user_id> <user_new_level>')
             return
         if not args[1].isdigit():
-            logger.warning(f'user_id is not int')
+            logger.warning('user_id is not int.')
             await message.reply("❌ user_id має бути числом")
             return
         
         target_id = int(args[1])
-        target_new_level = args[2]
+        target_level_name = args[2]
 
-        if target_new_level not in Level.__members__:
+        if target_level_name not in Level.__members__:
             levels = ', '.join(Level.__members__)
-            logger.warning(f'Unknown level.')
+            logger.warning('Unknown level.')
             await message.reply(f'❌ Невідомий рівень. Доступні рівні: {levels}')
             return
         
-        new_level = Level[target_new_level]
+        new_level = Level[target_level_name]
         target_df = ut.get_user_by_id(target_id) 
 
         if target_df.empty:
-                logger.warning('Target user is empty')
-                await message.reply('Незнайдено вказаного користувача')
-                return
+            logger.warning('Target user is empty')
+            await message.reply('Незнайдено вказаного користувача')
+            return
         
         target_user = ut.pandas2pydentic(target_df)
         old_level = target_user.level
@@ -397,8 +397,8 @@ async def cmd_setlevel(message: types.Message, logger, bot: Bot):
         except Exception:
             logger.warning(f'Невдалось повідомити користувача про зміну рівня{target_id}.')
         await message.reply(f'✅ Рівень користувача {target_user.full_name} змінено на {target_user.level.name}')
-    except Exception as e:
-        logger.exception(f"Проблема в /setlevel: {e}")
+    except Exception:
+        logger.exception(f"Проблема в /setlevel")
         await message.reply("❌ Виникла несподівана помилка")
 
 

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -382,7 +382,7 @@ async def cmd_setlevel(message: types.Message, logger, bot: Bot):
         
         target_user.level = new_level
         ut.update_row(target_user)
-        await bot.send_message(target_id, f'Твій новий level: {target_user.level}.')
+        await bot.send_message(target_id, f'Твій новий level: {target_user.level.name}.')
         await message.reply(f'✅ Рівень користувача {target_user.full_name} змінено на {target_user.level.name}')
 
     except Exception as e:

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -392,7 +392,10 @@ async def cmd_setlevel(message: types.Message, logger, bot: Bot):
         logger.info(f'/setlevel {target_id} ({target_user.full_name}): {old_level.name} -> {new_level.name}')
         target_user.level = new_level
         ut.update_row(target_user)
-        await bot.send_message(target_id, f'Твій новий level: {target_user.level.name}.')
+        try:
+            await bot.send_message(target_id, f'Твій новий level: {target_user.level.name}.')
+        except Exception:
+            logger.warning(f'Невдалось повідомити користувача про зміну рівня{target_id}.')
         await message.reply(f'✅ Рівень користувача {target_user.full_name} змінено на {target_user.level.name}')
     except Exception as e:
         logger.exception(f"Проблема в /setlevel: {e}")

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -345,3 +345,33 @@ async def cmd_show_users_mb(message: types.Message, logger, cfg):
     except Exception as e:
         logger.exception(f"Проблема при зчитуванні користувачів: {e}")
         await message.reply("❌ Виникла помилка при зчитуванні таблиці користувачів.")
+
+@router.message(Command('setlevel'))
+async def cmd_setlevel(message: types.Message, logger, cfg, bot: Bot):
+    user_bot = message.from_user
+    user_df = ut.get_user_by_id(user_bot.id)
+    user = ut.pandas2pydentic(user_df)
+    args = message.text.split()
+    if len(args) != 3:
+        await message.reply('Формат: /setlevel <user_id> <user_new_level>')
+        levels = ', '.join(l.name for l in Level)
+        await message.reply(f'Доступні рівні: {levels}')
+        return
+    target_id = int(args[1])
+    target_new_level = args[2]
+    target_df=ut.get_user_by_id(target_id)
+    target_user=ut.pandas2pydentic(target_df)
+
+    logger.info(f'target_id= {target_id}, target_new_level= {target_new_level}, target_current_level= {target_user.level}')
+    try:
+        if user.level != Level.admin:
+            await message.reply('Вибачте, але у вас нема доступу до цієї команди')
+            return
+        else:
+            target_user.level = Level[target_new_level]
+            ut.update_row(target_user)
+            await bot.send_message(target_id, f'Твій новий level: {target_user.level}.')
+    except Exception as e:
+        logger.exception(f"Проблема при зчитуванні користувачів: {e}")
+        await message.reply("❌ Виникла помилка при зчитуванні таблиці користувачів.")
+    

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -348,30 +348,35 @@ async def cmd_show_users_mb(message: types.Message, logger, cfg):
 
 @router.message(Command('setlevel'))
 async def cmd_setlevel(message: types.Message, logger, cfg, bot: Bot):
-    user_bot = message.from_user
-    user_df = ut.get_user_by_id(user_bot.id)
-    user = ut.pandas2pydentic(user_df)
-    args = message.text.split()
-    if len(args) != 3:
-        await message.reply('Формат: /setlevel <user_id> <user_new_level>')
-        levels = ', '.join(l.name for l in Level)
-        await message.reply(f'Доступні рівні: {levels}')
+    user = await check_access(message, [Level.admin])
+    if not user:
         return
-    target_id = int(args[1])
-    target_new_level = args[2]
-    target_df=ut.get_user_by_id(target_id)
-    target_user=ut.pandas2pydentic(target_df)
-
-    logger.info(f'target_id= {target_id}, target_new_level= {target_new_level}, target_current_level= {target_user.level}')
+    
     try:
-        if user.level != Level.admin:
-            await message.reply('Вибачте, але у вас нема доступу до цієї команди')
-            return
-        else:
-            target_user.level = Level[target_new_level]
-            ut.update_row(target_user)
-            await bot.send_message(target_id, f'Твій новий level: {target_user.level}.')
+        try:
+            args = message.text.split()
+            if len(args) != 3:
+                await message.reply('Формат: /setlevel <user_id> <user_new_level>')
+                levels = ', '.join(l.name for l in Level)
+                await message.reply(f'Доступні рівні: {levels}')
+                return
+            target_id = int(args[1]) 
+        except ValueError:
+            await message.reply("❌ user_id має бути числом")
+
+        target_new_level = args[2]
+        target_df=ut.get_user_by_id(target_id)
+        target_user=ut.pandas2pydentic(target_df)
+
+        if target_df.empty:
+                await message.reply('Незнайдено вказаного користувача')
+                return
+        
+        target_user.level = Level[target_new_level]
+        ut.update_row(target_user)
+        await bot.send_message(target_id, f'Твій новий level: {target_user.level}.')
+
     except Exception as e:
-        logger.exception(f"Проблема при зчитуванні користувачів: {e}")
-        await message.reply("❌ Виникла помилка при зчитуванні таблиці користувачів.")
+        logger.exception(f"Проблема в /setlevel: {e}")
+        await message.reply("❌ Виникла несподівана помилка")
     

--- a/justfile
+++ b/justfile
@@ -4,6 +4,12 @@ setup:
     git config --unset-all core.hooksPath || true
     pre-commit install
 
+# Run the bot. Auto-updates yt-dlp first so the TikTok/Instagram/YouTube
+# extractors stay fresh (they break often and are fixed by yt-dlp releases).
+run:
+    pip install -U yt-dlp
+    python main.py
+
 # Lint: blocking errors only (same as CI)
 lint:
     ruff check --select E9,F63,F7,F82 .

--- a/justfile
+++ b/justfile
@@ -53,6 +53,11 @@ review pr:
         tmux attach-session -t "$session"
     fi
 
+
+review_watcher:
+  #!/usr/bin/env bash
+  tmux new-session -d -s review-queue 'just queue-watch'
+
 # Watch /tmp/tele-bot-review-queue/pending/ for review requests from the bot.
 # The bot's /review handler writes JSON files there with caller info + PR number.
 # This watcher picks each up and spawns `claude --print '/review-pr-ukr N'` in tmux.
@@ -129,11 +134,11 @@ queue-watch:
              echo 'claude --version:'; claude --version 2>/dev/null || true; \
              echo 'PWD:' \$(pwd); \
              echo; \
-             echo '──── claude output (verbose) ────'; \
-             ( while sleep 20; do echo \"[\$(date +'%F %T')] ⏳ still working...\"; done ) & HB=\$!; \
-             claude --verbose --print '/review-pr-ukr $pr' 2>&1 | awk '{ print strftime(\"[%F %T]\"), \$0; fflush() }'; \
+             echo '──── claude output ────'; \
+             claude --output-format stream-json '/review-pr-ukr $pr' 2>&1 \
+               | jq -r --unbuffered 'if .type == \"assistant\" then (.message.content[] | select(.type == \"text\") | .text) elif .type == \"result\" then \"\\n✅ Done (exit=\\(.subtype))\" else empty end' 2>/dev/null \
+               | awk '{ print strftime(\"[%F %T]\"), \$0; fflush() }'; \
              rc=\${PIPESTATUS[0]}; \
-             kill \$HB 2>/dev/null; wait \$HB 2>/dev/null; \
              echo; echo \"──── claude exit=\$rc ────\"; \
              jq --arg ts \"\$(date -u +%FT%TZ)\" --argjson rc \$rc --arg log '$log' \
                 '. + {completed_at: \$ts, exit_code: \$rc, status: (if \$rc == 0 then \"success\" else \"failed\" end), log_file: \$log}' \

--- a/justfile
+++ b/justfile
@@ -135,10 +135,10 @@ queue-watch:
              echo 'PWD:' \$(pwd); \
              echo; \
              echo '──── claude output ────'; \
-             claude --output-format stream-json '/review-pr-ukr $pr' 2>&1 \
+             claude --print --output-format stream-json '/review-pr-ukr $pr' 2>&1 \
                | jq -r --unbuffered 'if .type == \"assistant\" then (.message.content[] | select(.type == \"text\") | .text) elif .type == \"result\" then \"\\n✅ Done (exit=\\(.subtype))\" else empty end' 2>/dev/null \
                | awk '{ print strftime(\"[%F %T]\"), \$0; fflush() }'; \
-             rc=\${PIPESTATUS[0]}; \
+             rc=\${PIPESTATUS[0]}; rc=\${rc:-1}; \
              echo; echo \"──── claude exit=\$rc ────\"; \
              jq --arg ts \"\$(date -u +%FT%TZ)\" --argjson rc \$rc --arg log '$log' \
                 '. + {completed_at: \$ts, exit_code: \$rc, status: (if \$rc == 0 then \"success\" else \"failed\" end), log_file: \$log}' \

--- a/main.py
+++ b/main.py
@@ -184,19 +184,17 @@ async def handle_inst_tick(message: types.Message, cfg):
         ),
         url=message.text,
     )
-    logger.info(f'<<<<<{loc_video}')
     try:
         if loc_video.endswith('mp4'):
             await message.answer_video(
                 video=types.FSInputFile(loc_video), caption=answer_cap)
         else:
             await message.answer_audio(
-                video=types.FSInputFile(loc_video), caption=answer_cap)
+                audio=types.FSInputFile(loc_video), caption=answer_cap)
     except Exception as e:
         await message.reply(f"An error occurred while sending the video: {e}")
     user.use_memory += file_size
-    loc_match = glob.glob(os.path.join(".", f"{loc_video.replace("%(ext)s", "")}.*"))
-    assert loc_match
+    loc_match = glob.glob(os.path.join(".", f"{loc_video}*"))
     loc_video = loc_match[0]
     ut.update_row(user)
     ut.delete_video_file(loc_video)

--- a/main.py
+++ b/main.py
@@ -185,7 +185,8 @@ async def handle_inst_tick(message: types.Message, cfg):
         url=message.text,
     )
     try:
-        if loc_video.endswith('mp4'):
+        ext = os.path.splitext(loc_video)[1].lower()
+        if ext in ('.mp4', '.mkv', '.webm'):
             await message.answer_video(
                 video=types.FSInputFile(loc_video), caption=answer_cap)
         else:
@@ -194,8 +195,6 @@ async def handle_inst_tick(message: types.Message, cfg):
     except Exception as e:
         await message.reply(f"An error occurred while sending the video: {e}")
     user.use_memory += file_size
-    loc_match = glob.glob(os.path.join(".", f"{loc_video}*"))
-    loc_video = loc_match[0]
     ut.update_row(user)
     ut.delete_video_file(loc_video)
 

--- a/main.py
+++ b/main.py
@@ -187,9 +187,11 @@ async def handle_inst_tick(message: types.Message, cfg):
     try:
         ext = os.path.splitext(loc_video)[1].lower()
         if ext in ('.mp4', '.mkv', '.webm'):
+            logger.info(f'Sending as video: {loc_video}')
             await message.answer_video(
                 video=types.FSInputFile(loc_video), caption=answer_cap)
         else:
+            logger.info(f'Sending as audio: {loc_video}')
             await message.answer_audio(
                 audio=types.FSInputFile(loc_video), caption=answer_cap)
     except Exception as e:

--- a/main.py
+++ b/main.py
@@ -184,15 +184,18 @@ async def handle_inst_tick(message: types.Message, cfg):
         ),
         url=message.text,
     )
-
+    logger.info(f'<<<<<{loc_video}')
     try:
-        await message.answer_video(
-            video=types.FSInputFile(loc_video), caption=answer_cap
-        )
+        if loc_video.endswith('mp4'):
+            await message.answer_video(
+                video=types.FSInputFile(loc_video), caption=answer_cap)
+        else:
+            await message.answer_audio(
+                video=types.FSInputFile(loc_video), caption=answer_cap)
     except Exception as e:
         await message.reply(f"An error occurred while sending the video: {e}")
     user.use_memory += file_size
-    loc_match = glob.glob(os.path.join(".", f"{loc_video}*"))
+    loc_match = glob.glob(os.path.join(".", f"{loc_video.replace("%(ext)s", "")}.*"))
     assert loc_match
     loc_video = loc_match[0]
     ut.update_row(user)

--- a/main.py
+++ b/main.py
@@ -168,7 +168,7 @@ async def handle_inst_tick(message: types.Message, cfg):
         "outtmpl": loc_video,
     }
 
-    res = await bot_func.get_dwn_media(ydl_opts, message)
+    res = await bot_func.get_dwn_media(ydl_opts, message, user_id=user.id)
     if not res:
         await message.answer(
             "Не вдалося завантажити. Перевір посилання і спробуй ще раз."

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ python-dotenv==1.0.1
 pyyaml==6.0.2
 tomli==2.0.1
 tqdm==4.67.1
-yt-dlp==2025.3.27
+yt-dlp>=2026.3.17
 curl_cffi==0.10.0
 easydict==1.13
 srtools==0.1.13

--- a/src/bot.py
+++ b/src/bot.py
@@ -14,6 +14,35 @@ from aiogram import types
 
 LIMIT_SIZE_UPL_VIDEO = 49
 
+# How many times to retry a download when a *transient* error happens
+# (e.g. TikTok "rehydration" extraction flakiness — the same link often
+# succeeds on the next attempt). Backoff grows: RETRY_BASE_DELAY * attempt.
+MAX_DOWNLOAD_ATTEMPTS = 4
+RETRY_BASE_DELAY = 1.5
+
+# Substrings that mark a *temporary* failure worth retrying. Anything else
+# (private/removed video, unsupported URL, ...) fails immediately.
+_RETRIABLE_MARKERS = (
+    "rehydration",
+    "universal data",
+    "unable to extract",
+    "unable to download webpage",
+    "challenge",
+    "timed out",
+    "timeout",
+    "connection",
+    "temporarily",
+    "http error 5",
+    "read timed out",
+)
+
+
+def _is_retriable_error(msg: str) -> bool:
+    """True if the yt-dlp error message looks like a transient, retriable one."""
+    low = msg.lower()
+    return any(marker in low for marker in _RETRIABLE_MARKERS)
+
+
 vid_format_dict = {
     "audio only": "🎧",
     "256x144": "144p",
@@ -210,14 +239,56 @@ class Bot_Func:
                     pass
 
             ydl_opts_with_hook = {
+                # Network/extractor robustness defaults — caller's ydl_opts may
+                # override any of these via the spread below.
+                "retries": 5,
+                "fragment_retries": 5,
+                "extractor_retries": 3,
+                "socket_timeout": 30,
                 **ydl_opts,
                 "progress_hooks": [progress_hook],
                 "postprocessor_hooks": [pp_hook],
             }
 
             def download():
-                with yt_dlp.YoutubeDL(ydl_opts_with_hook) as ydl:
-                    return ydl.extract_info(med_url, download=True)
+                # Retry transient failures (TikTok rehydration flakiness, timeouts,
+                # transient network errors). The same link that fails once usually
+                # succeeds on the next attempt — see logs in the bug report.
+                base = re.sub(r"\.?%\([^)]+\)s", "", loc_video)
+                last_err = None
+                for attempt in range(1, MAX_DOWNLOAD_ATTEMPTS + 1):
+                    try:
+                        with yt_dlp.YoutubeDL(ydl_opts_with_hook) as ydl:
+                            return ydl.extract_info(med_url, download=True)
+                    except yt_dlp.utils.DownloadError as e:
+                        last_err = e
+                        if attempt >= MAX_DOWNLOAD_ATTEMPTS or not _is_retriable_error(
+                            str(e)
+                        ):
+                            raise
+                        self.log.warning(
+                            f"⚠️ Download attempt {attempt}/{MAX_DOWNLOAD_ATTEMPTS} "
+                            f"failed (retriable), retrying: {e}"
+                        )
+                        # Let the user know we're retrying (best-effort).
+                        asyncio.run_coroutine_threadsafe(
+                            _edit_progress(
+                                f"⚠️ Спроба {attempt} не вдалась, пробую ще раз…"
+                            ),
+                            loop,
+                        )
+                        # Drop half-downloaded leftovers before the next attempt.
+                        if base:
+                            for leftover in glob.glob(glob.escape(base) + "*"):
+                                if leftover.endswith((".part", ".ytdl")):
+                                    try:
+                                        os.remove(leftover)
+                                    except OSError:
+                                        pass
+                        time.sleep(RETRY_BASE_DELAY * attempt)
+                # Exhausted retries — re-raise for the outer DownloadError handler.
+                if last_err:
+                    raise last_err
 
             media_info = await asyncio.to_thread(download)
             await strt_dwn_msg.delete()

--- a/src/bot.py
+++ b/src/bot.py
@@ -244,10 +244,13 @@ class Bot_Func:
         return ""
 
     def _record_download_issue(
-        self, url, reason, media_info=None, error=None, chat_id=None
+        self, url, reason, media_info=None, error=None, chat_id=None, user_id=None
     ) -> None:
         """Append a JSONL record (logs/download_issues.jsonl) for a failed or
-        audioless download, so the problem can be understood and reproduced."""
+        audioless download, so the problem can be understood and reproduced.
+
+        ``chat_id`` is where it happened (may be a group); ``user_id`` is who
+        triggered it (the real person, passed in by the handler)."""
         try:
             vcodec, acodec = _codecs_of(media_info)
             src = ((media_info or {}).get("requested_downloads") or [{}])[0] or (
@@ -258,6 +261,7 @@ class Bot_Func:
                 "reason": reason,
                 "url": url,
                 "error": str(error) if error else None,
+                "user_id": user_id,
                 "chat_id": chat_id,
                 "yt_dlp": getattr(getattr(yt_dlp, "version", None), "__version__", "?"),
                 "extractor": (media_info or {}).get("extractor_key"),
@@ -275,10 +279,12 @@ class Bot_Func:
         except Exception as e:
             self.log.error(f"Failed to record download issue: {e}")
 
-    async def get_dwn_media(self, ydl_opts, user_msg, youtubeLink=""):
+    async def get_dwn_media(self, ydl_opts, user_msg, youtubeLink="", user_id=None):
         med_url = youtubeLink if youtubeLink else user_msg.text
 
         loc_video = ydl_opts["outtmpl"]
+        # chat_id = where it happened (can be a group); user_id = who (passed by
+        # the handler, since for bot-sent messages user_msg.from_user is the bot).
         chat_id = getattr(getattr(user_msg, "chat", None), "id", None)
 
         strt_dwn_msg = None
@@ -385,6 +391,7 @@ class Bot_Func:
                     "video_without_audio",
                     media_info=media_info,
                     chat_id=chat_id,
+                    user_id=user_id,
                 )
                 silent = self._resolve_downloaded_file(loc_video, finished_file)
                 if silent:
@@ -396,6 +403,19 @@ class Bot_Func:
                     "format": "best[acodec!=none][vcodec!=none]/best",
                 }
                 media_info = await asyncio.to_thread(download, combined_opts)
+                # If the combined refetch is *still* silent, don't let it pass
+                # unnoticed — record it so the blind spot stays diagnosable.
+                if _is_video_without_audio(media_info):
+                    self.log.error(
+                        "❌ Still no audio after combined-format refetch"
+                    )
+                    self._record_download_issue(
+                        med_url,
+                        "still_no_audio_after_recovery",
+                        media_info=media_info,
+                        chat_id=chat_id,
+                        user_id=user_id,
+                    )
 
             await strt_dwn_msg.delete()
             self.log.success(f"✅ Download successful! {loc_video}")
@@ -408,6 +428,7 @@ class Bot_Func:
                 media_info=media_info,
                 error=e,
                 chat_id=chat_id,
+                user_id=user_id,
             )
             if strt_dwn_msg:
                 await strt_dwn_msg.delete()
@@ -425,7 +446,11 @@ class Bot_Func:
         if not resolved:
             self.log.error(f"Download finished but file not found. {loc_video=}")
             self._record_download_issue(
-                med_url, "file_not_found", media_info=media_info, chat_id=chat_id
+                med_url,
+                "file_not_found",
+                media_info=media_info,
+                chat_id=chat_id,
+                user_id=user_id,
             )
             await user_msg.reply(f"Download finished but file not found. {loc_video=}")
             return

--- a/src/bot.py
+++ b/src/bot.py
@@ -69,11 +69,19 @@ def _cleanup_partial_downloads(base: str) -> None:
                 os.remove(leftover)
 
 
+def _source_stream_dict(media_info: dict | None) -> dict:
+    """The actually-downloaded stream dict. yt-dlp puts merged/remuxed stream
+    data under ``requested_downloads[0]``; fall back to the top-level info."""
+    if not media_info:
+        return {}
+    return (media_info.get("requested_downloads") or [{}])[0] or media_info
+
+
 def _codecs_of(media_info: dict | None) -> tuple[str, str]:
     """Return (vcodec, acodec) of the actually-downloaded stream, lowercased."""
     if not media_info:
         return "", ""
-    src = (media_info.get("requested_downloads") or [{}])[0] or media_info
+    src = _source_stream_dict(media_info)
     vcodec = ((src.get("vcodec") or media_info.get("vcodec")) or "").lower()
     acodec = ((src.get("acodec") or media_info.get("acodec")) or "").lower()
     return vcodec, acodec
@@ -118,11 +126,7 @@ class Bot_Func:
         """Log codec/resolution/bitrate and return the same text for sidecar writing."""
         if not info:
             return ""
-        # For merged/remuxed formats the final stream data lives under
-        # requested_downloads[0]; fall back to top-level info_dict fields.
-        rd = (info.get("requested_downloads") or [{}])[0]
-        src = rd if rd else info
-
+        src = _source_stream_dict(info)
         vcodec = src.get("vcodec") or info.get("vcodec", "?")
         acodec = src.get("acodec") or info.get("acodec", "?")
         width = src.get("width") or info.get("width")
@@ -253,9 +257,7 @@ class Bot_Func:
         triggered it (the real person, passed in by the handler)."""
         try:
             vcodec, acodec = _codecs_of(media_info)
-            src = ((media_info or {}).get("requested_downloads") or [{}])[0] or (
-                media_info or {}
-            )
+            src = _source_stream_dict(media_info)
             record = {
                 "ts": datetime.now().isoformat(timespec="seconds"),
                 "reason": reason,

--- a/src/bot.py
+++ b/src/bot.py
@@ -2,6 +2,7 @@
 from src import utils as ut
 import contextlib
 import glob
+import json
 import re
 from datetime import datetime
 from pathlib import Path
@@ -66,6 +67,22 @@ def _cleanup_partial_downloads(base: str) -> None:
         if leftover.endswith((".part", ".ytdl")):
             with contextlib.suppress(OSError):
                 os.remove(leftover)
+
+
+def _codecs_of(media_info: dict | None) -> tuple[str, str]:
+    """Return (vcodec, acodec) of the actually-downloaded stream, lowercased."""
+    if not media_info:
+        return "", ""
+    src = (media_info.get("requested_downloads") or [{}])[0] or media_info
+    vcodec = ((src.get("vcodec") or media_info.get("vcodec")) or "").lower()
+    acodec = ((src.get("acodec") or media_info.get("acodec")) or "").lower()
+    return vcodec, acodec
+
+
+def _is_video_without_audio(media_info: dict | None) -> bool:
+    """True only when we *know* it's a video stream with no audio track."""
+    vcodec, acodec = _codecs_of(media_info)
+    return vcodec not in ("", "none") and acodec == "none"
 
 
 vid_format_dict = {
@@ -137,8 +154,7 @@ class Bot_Func:
         """Transcode to H.264/AAC if the video codec is not Apple-compatible."""
         if not media_info:
             return path
-        rd = (media_info.get("requested_downloads") or [{}])[0]
-        vcodec = ((rd.get("vcodec") or media_info.get("vcodec")) or "").lower()
+        vcodec, _ = _codecs_of(media_info)
         # "none" == audio-only download (mp3 etc.): nothing to transcode.
         if not vcodec or vcodec == "none" or vcodec.startswith(self._APPLE_VCODECS):
             return path  # already fine
@@ -208,10 +224,61 @@ class Bot_Func:
             self.log.error(f"YouTube search error: {e}")
             return []
 
+    def _resolve_downloaded_file(self, outtmpl: str, finished_file: str) -> str:
+        """Find the real downloaded file: hook result first, then glob fallback."""
+        if finished_file and os.path.exists(finished_file):
+            return finished_file
+        base_path = _strip_outtmpl_vars(outtmpl)
+        if base_path.endswith("/"):
+            # Template was directory-only — pick newest non-part file in dir.
+            candidates = [
+                f
+                for f in glob.glob(os.path.join(base_path, "*"))
+                if not f.endswith(".part") and os.path.isfile(f)
+            ]
+            return max(candidates, key=os.path.getmtime) if candidates else ""
+        if base_path:
+            loc_match = glob.glob(os.path.join(".", glob.escape(base_path) + "*"))
+            if loc_match:
+                return loc_match[0]
+        return ""
+
+    def _record_download_issue(
+        self, url, reason, media_info=None, error=None, chat_id=None
+    ) -> None:
+        """Append a JSONL record (logs/download_issues.jsonl) for a failed or
+        audioless download, so the problem can be understood and reproduced."""
+        try:
+            vcodec, acodec = _codecs_of(media_info)
+            src = (media_info or {}).get("requested_downloads") or [{}]
+            src = src[0] or (media_info or {})
+            record = {
+                "ts": datetime.now().isoformat(timespec="seconds"),
+                "reason": reason,
+                "url": url,
+                "error": str(error) if error else None,
+                "chat_id": chat_id,
+                "yt_dlp": getattr(getattr(yt_dlp, "version", None), "__version__", "?"),
+                "extractor": (media_info or {}).get("extractor_key"),
+                "format_id": src.get("format_id"),
+                "vcodec": vcodec or None,
+                "acodec": acodec or None,
+                "ext": src.get("ext"),
+                "filesize": src.get("filesize") or src.get("filesize_approx"),
+            }
+            path = self.root_prj / "logs" / "download_issues.jsonl"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+            self.log.info(f"📝 Recorded download issue ({reason}) → {path}")
+        except Exception as e:
+            self.log.error(f"Failed to record download issue: {e}")
+
     async def get_dwn_media(self, ydl_opts, user_msg, youtubeLink=""):
         med_url = youtubeLink if youtubeLink else user_msg.text
 
         loc_video = ydl_opts["outtmpl"]
+        chat_id = getattr(getattr(user_msg, "chat", None), "id", None)
 
         strt_dwn_msg = None
         finished_file: str = ""
@@ -273,7 +340,7 @@ class Bot_Func:
                 "postprocessor_hooks": [pp_hook],
             }
 
-            def download():
+            def download(opts):
                 # Retry transient failures (TikTok rehydration flakiness, timeouts,
                 # transient network errors). The same link that fails once usually
                 # succeeds on the next attempt — see logs in the bug report. The
@@ -282,7 +349,7 @@ class Bot_Func:
                 base = _strip_outtmpl_vars(loc_video)
                 for attempt in range(1, MAX_DOWNLOAD_ATTEMPTS + 1):
                     try:
-                        with yt_dlp.YoutubeDL(ydl_opts_with_hook) as ydl:
+                        with yt_dlp.YoutubeDL(opts) as ydl:
                             return ydl.extract_info(med_url, download=True)
                     except yt_dlp.utils.DownloadError as e:
                         if attempt >= MAX_DOWNLOAD_ATTEMPTS or not _is_retriable_error(
@@ -303,12 +370,44 @@ class Bot_Func:
                         _cleanup_partial_downloads(base)
                         time.sleep(RETRY_BASE_DELAY * attempt)
 
-            media_info = await asyncio.to_thread(download)
+            media_info = await asyncio.to_thread(download, ydl_opts_with_hook)
+
+            # Some sites (notably TikTok) occasionally hand back a video-only
+            # stream, so the result has no sound. Re-fetch once forcing a
+            # combined audio+video format. (Bug report: "sometimes no audio".)
+            if _is_video_without_audio(media_info):
+                self.log.warning(
+                    "⚠️ Downloaded video has no audio — refetching combined format"
+                )
+                self._record_download_issue(
+                    med_url,
+                    "video_without_audio",
+                    media_info=media_info,
+                    chat_id=chat_id,
+                )
+                silent = self._resolve_downloaded_file(loc_video, finished_file)
+                if silent:
+                    ut.delete_video_file(silent)
+                _cleanup_partial_downloads(_strip_outtmpl_vars(loc_video))
+                finished_file = ""
+                combined_opts = {
+                    **ydl_opts_with_hook,
+                    "format": "best[acodec!=none][vcodec!=none]/best",
+                }
+                media_info = await asyncio.to_thread(download, combined_opts)
+
             await strt_dwn_msg.delete()
             self.log.success(f"✅ Download successful! {loc_video}")
             self._log_media_info(media_info)
         except yt_dlp.utils.DownloadError as e:
             self.log.error(f"❌ Download error: {e}")
+            self._record_download_issue(
+                med_url,
+                "download_error",
+                media_info=media_info,
+                error=e,
+                chat_id=chat_id,
+            )
             if strt_dwn_msg:
                 await strt_dwn_msg.delete()
             await user_msg.reply(f"Download error: {e}")
@@ -320,29 +419,13 @@ class Bot_Func:
             await user_msg.reply(f"An error occurred: {e}")
             return
 
-        # Resolve actual file path: prefer postprocessor-hook result, then
-        # progress-hook result, then glob fallback.
-        resolved: str = ""
-        if finished_file and os.path.exists(finished_file):
-            resolved = finished_file
-        else:
-            base_path = _strip_outtmpl_vars(loc_video)
-            if base_path.endswith("/"):
-                # Template was directory-only — pick newest non-part file in dir
-                candidates = [
-                    f
-                    for f in glob.glob(os.path.join(base_path, "*"))
-                    if not f.endswith(".part") and os.path.isfile(f)
-                ]
-                if candidates:
-                    resolved = max(candidates, key=os.path.getmtime)
-            elif base_path:
-                loc_match = glob.glob(os.path.join(".", glob.escape(base_path) + "*"))
-                if loc_match:
-                    resolved = loc_match[0]
-
+        # Resolve actual file path (hook result first, then glob fallback).
+        resolved = self._resolve_downloaded_file(loc_video, finished_file)
         if not resolved:
             self.log.error(f"Download finished but file not found. {loc_video=}")
+            self._record_download_issue(
+                med_url, "file_not_found", media_info=media_info, chat_id=chat_id
+            )
             await user_msg.reply(f"Download finished but file not found. {loc_video=}")
             return
         loc_video = resolved

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,5 +1,6 @@
 # import utils as ut
 from src import utils as ut
+import contextlib
 import glob
 import re
 from datetime import datetime
@@ -41,6 +42,30 @@ def _is_retriable_error(msg: str) -> bool:
     """True if the yt-dlp error message looks like a transient, retriable one."""
     low = msg.lower()
     return any(marker in low for marker in _RETRIABLE_MARKERS)
+
+
+# Network/extractor robustness defaults shared by every yt-dlp call.
+_YDL_ROBUSTNESS_OPTS = {
+    "retries": 5,
+    "fragment_retries": 5,
+    "extractor_retries": 3,
+    "socket_timeout": 30,
+}
+
+
+def _strip_outtmpl_vars(template: str) -> str:
+    """Strip yt-dlp template vars (e.g. ".%(ext)s") to get the base path/prefix."""
+    return re.sub(r"\.?%\([^)]+\)s", "", template)
+
+
+def _cleanup_partial_downloads(base: str) -> None:
+    """Remove ``.part``/``.ytdl`` artifacts left by an interrupted yt-dlp run."""
+    if not base:
+        return
+    for leftover in glob.glob(glob.escape(base) + "*"):
+        if leftover.endswith((".part", ".ytdl")):
+            with contextlib.suppress(OSError):
+                os.remove(leftover)
 
 
 vid_format_dict = {
@@ -159,12 +184,7 @@ class Bot_Func:
     def extract_video_info(self, url):
         """Extract video metadata (title, thumbnail, duration). Blocking."""
         try:
-            opts = {
-                "quiet": True,
-                "skip_download": True,
-                "extractor_retries": 3,
-                "socket_timeout": 30,
-            }
+            opts = {"quiet": True, "skip_download": True, **_YDL_ROBUSTNESS_OPTS}
             with yt_dlp.YoutubeDL(opts) as ydl:
                 info = ydl.extract_info(url, download=False)
                 return {
@@ -246,12 +266,8 @@ class Bot_Func:
                     pass
 
             ydl_opts_with_hook = {
-                # Network/extractor robustness defaults — caller's ydl_opts may
-                # override any of these via the spread below.
-                "retries": 5,
-                "fragment_retries": 5,
-                "extractor_retries": 3,
-                "socket_timeout": 30,
+                # Robustness defaults — caller's ydl_opts may override via spread.
+                **_YDL_ROBUSTNESS_OPTS,
                 **ydl_opts,
                 "progress_hooks": [progress_hook],
                 "postprocessor_hooks": [pp_hook],
@@ -260,15 +276,15 @@ class Bot_Func:
             def download():
                 # Retry transient failures (TikTok rehydration flakiness, timeouts,
                 # transient network errors). The same link that fails once usually
-                # succeeds on the next attempt — see logs in the bug report.
-                base = re.sub(r"\.?%\([^)]+\)s", "", loc_video)
-                last_err = None
+                # succeeds on the next attempt — see logs in the bug report. The
+                # final attempt re-raises (attempt >= MAX), so the loop never falls
+                # through.
+                base = _strip_outtmpl_vars(loc_video)
                 for attempt in range(1, MAX_DOWNLOAD_ATTEMPTS + 1):
                     try:
                         with yt_dlp.YoutubeDL(ydl_opts_with_hook) as ydl:
                             return ydl.extract_info(med_url, download=True)
                     except yt_dlp.utils.DownloadError as e:
-                        last_err = e
                         if attempt >= MAX_DOWNLOAD_ATTEMPTS or not _is_retriable_error(
                             str(e)
                         ):
@@ -284,18 +300,8 @@ class Bot_Func:
                             ),
                             loop,
                         )
-                        # Drop half-downloaded leftovers before the next attempt.
-                        if base:
-                            for leftover in glob.glob(glob.escape(base) + "*"):
-                                if leftover.endswith((".part", ".ytdl")):
-                                    try:
-                                        os.remove(leftover)
-                                    except OSError:
-                                        pass
+                        _cleanup_partial_downloads(base)
                         time.sleep(RETRY_BASE_DELAY * attempt)
-                # Exhausted retries — re-raise for the outer DownloadError handler.
-                if last_err:
-                    raise last_err
 
             media_info = await asyncio.to_thread(download)
             await strt_dwn_msg.delete()
@@ -320,7 +326,7 @@ class Bot_Func:
         if finished_file and os.path.exists(finished_file):
             resolved = finished_file
         else:
-            base_path = re.sub(r"\.?%\([^)]+\)s", "", loc_video)
+            base_path = _strip_outtmpl_vars(loc_video)
             if base_path.endswith("/"):
                 # Template was directory-only — pick newest non-part file in dir
                 candidates = [

--- a/src/bot.py
+++ b/src/bot.py
@@ -114,7 +114,8 @@ class Bot_Func:
             return path
         rd = (media_info.get("requested_downloads") or [{}])[0]
         vcodec = ((rd.get("vcodec") or media_info.get("vcodec")) or "").lower()
-        if not vcodec or vcodec.startswith(self._APPLE_VCODECS):
+        # "none" == audio-only download (mp3 etc.): nothing to transcode.
+        if not vcodec or vcodec == "none" or vcodec.startswith(self._APPLE_VCODECS):
             return path  # already fine
 
         self.log.warning(
@@ -158,7 +159,13 @@ class Bot_Func:
     def extract_video_info(self, url):
         """Extract video metadata (title, thumbnail, duration). Blocking."""
         try:
-            with yt_dlp.YoutubeDL({"quiet": True, "skip_download": True}) as ydl:
+            opts = {
+                "quiet": True,
+                "skip_download": True,
+                "extractor_retries": 3,
+                "socket_timeout": 30,
+            }
+            with yt_dlp.YoutubeDL(opts) as ydl:
                 info = ydl.extract_info(url, download=False)
                 return {
                     "thumbnail": info.get("thumbnail", ""),

--- a/src/bot.py
+++ b/src/bot.py
@@ -250,8 +250,9 @@ class Bot_Func:
         audioless download, so the problem can be understood and reproduced."""
         try:
             vcodec, acodec = _codecs_of(media_info)
-            src = (media_info or {}).get("requested_downloads") or [{}]
-            src = src[0] or (media_info or {})
+            src = ((media_info or {}).get("requested_downloads") or [{}])[0] or (
+                media_info or {}
+            )
             record = {
                 "ts": datetime.now().isoformat(timespec="seconds"),
                 "reason": reason,


### PR DESCRIPTION
## Контекст

TikTok-посилання (особливо в групах) інколи не завантажувались: yt-dlp періодично падав з `Unable to extract universal data for rehydration` — переривчаста (flaky) помилка екстрактора, де те саме посилання якраз качається з наступної спроби. Ретраю не було. Плюс кілька суміжних проблем (відео без звуку, транскод аудіо як відео) і брак діагностики.

> ⚠️ Гілку відгалужено від `master` і **влито `dev`** (гілки розійшлися), тож сюди входять і фічі з `dev` (setlevel, fix_missing_ext, hidden_review тощо), і нові фікси нижче. Merge-конфлікти (`handlers/media_bot.py`, `justfile`) вирішені.

## Що нового (мої коміти)

**Стійкість завантаження** (`src/bot.py`)
- Авто-ретрай у `get_dwn_media` до 4 спроб з backoff ~1.5с/3с/4.5с, **лише** для тимчасових помилок (`_is_retriable_error`). Приватне/видалене відео падає одразу.
- Дефолтні yt-dlp opts: `retries`/`fragment_retries`/`extractor_retries`/`socket_timeout`. Очистка `.part`/`.ytdl` між спробами, повідомлення юзеру про ретрай.

**Відео без звуку**
- Детект `vcodec≠none && acodec==none` (TikTok інколи віддає video-only потік) → видаляємо «німий» файл і **перекачуємо один раз** гарантовано комбінованим форматом.

**Діагностика** — `logs/download_issues.jsonl`
- `_record_download_issue` дописує JSON-рядок на `download_error` / `video_without_audio` / `file_not_found`: url, причина, format_id, vcodec/acodec, ext, розмір, екстрактор, версія yt-dlp, chat_id, час. Лише коли щось не так.

**Дрібні фікси**
- `_ensure_h264` більше не транскодує аудіо (`vcodec=="none"`) — раніше кожен MP3 тягнув марний ffmpeg + хибне «Converting to H.264».
- inline-завантаження тепер з `.%(ext)s` в `outtmpl` (як решта шляхів).
- `extract_video_info` (inline-прев'ю) з retry/timeout.

**Свіжий yt-dlp**
- `just run` робить `pip install -U yt-dlp` перед стартом; `requirements.txt`: `yt-dlp>=2026.3.17`.

## Inline mode
Перевірено код inline-пошуку/завантаження — логіка робоча, пофікшено баг з `.%(ext)s`. ⚠️ Inline має бути увімкнений у @BotFather (`/setinline`) — це поза кодом.

## Перевірка
- `python -m compileall` + `ruff` (blocking) — зелено.
- Юніт-тести логіки: `_is_retriable_error` проти реального рядка помилки з логів, `_codecs_of`/`_is_video_without_audio`, `_strip_outtmpl_vars` — усі проходять.
- Прогнано `/simplify` (винесено спільні opts/хелпери, прибрано мертвий код) і `/code-review` (high; 1 чистка застосована, решта кандидатів — підтверджені хибні).

🤖 Generated with [Claude Code](https://claude.com/claude-code)