### PR TITLE
Класифікація помилок завантаження: DownloadErrorKind enum + тести

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,6 @@ assets
 **/*test*.py
 data/reg_user.csv
 .vscode
+
+# Project unit tests are versioned (override the generic *test*.py rules above)
+!tests/**/*.py

--- a/src/bot.py
+++ b/src/bot.py
@@ -4,10 +4,14 @@ import contextlib
 import glob
 import json
 import re
-from enum import Enum
 from datetime import datetime
 from pathlib import Path
 import yt_dlp
+from src.download_errors import (
+    classify_download_error,
+    is_retriable_error,
+    ERROR_USER_MESSAGES,
+)
 import os
 import asyncio
 import time
@@ -22,138 +26,6 @@ LIMIT_SIZE_UPL_VIDEO = 49
 # succeeds on the next attempt). Backoff grows: RETRY_BASE_DELAY * attempt.
 MAX_DOWNLOAD_ATTEMPTS = 4
 RETRY_BASE_DELAY = 1.5
-
-class DownloadErrorKind(Enum):
-    """Category of a yt-dlp download failure, inferred from its error text.
-
-    Drives three things: whether we retry (transient kinds only), what message
-    the user sees, and how the failure is tagged in logs/download_issues.jsonl.
-    """
-
-    AGE_RESTRICTED = "age_restricted"  # site wants sign-in to confirm age
-    LOGIN_REQUIRED = "login_required"  # private / sign-in / bot-check
-    UNAVAILABLE = "unavailable"  # removed / deleted / private / not found
-    GEO_BLOCKED = "geo_blocked"  # not available in this country
-    RATE_LIMITED = "rate_limited"  # HTTP 429 / too many requests
-    UNSUPPORTED = "unsupported"  # unsupported URL / no extractor / no formats
-    NETWORK = "network"  # timeout / connection / 5xx (transient)
-    EXTRACTION = "extraction"  # rehydration / "unable to extract" (flaky)
-    UNKNOWN = "unknown"  # anything we could not classify
-
-
-# Ordered most-specific → most-generic: the first kind with a matching
-# substring wins, so AGE/LOGIN/UNAVAILABLE are checked before the broad
-# EXTRACTION markers. Match is a case-insensitive substring of the message.
-_ERROR_KIND_MARKERS: dict[DownloadErrorKind, tuple[str, ...]] = {
-    DownloadErrorKind.AGE_RESTRICTED: (
-        "confirm your age",
-        "age-restricted",
-        "age restricted",
-        "inappropriate for some users",
-    ),
-    DownloadErrorKind.LOGIN_REQUIRED: (
-        "sign in to confirm you're not a bot",
-        "sign in",
-        "log in to",
-        "login required",
-        "requires authentication",
-        "private video",
-        "this video is private",
-        "this account is private",
-        "use --cookies",
-    ),
-    DownloadErrorKind.GEO_BLOCKED: (
-        "not available in your country",
-        "in your country",
-        "geo restricted",
-        "geo-restricted",
-    ),
-    DownloadErrorKind.RATE_LIMITED: (
-        "http error 429",
-        "too many requests",
-        "rate-limit",
-        "rate limit",
-    ),
-    DownloadErrorKind.UNAVAILABLE: (
-        "video unavailable",
-        "no longer available",
-        "has been removed",
-        "was deleted",
-        "this post may not be available",
-        "http error 404",
-        "account has been terminated",
-    ),
-    DownloadErrorKind.UNSUPPORTED: (
-        "unsupported url",
-        "no suitable extractor",
-        "no video formats found",
-        "is not a valid url",
-    ),
-    DownloadErrorKind.NETWORK: (
-        "timed out",
-        "timeout",
-        "read timed out",
-        "connection",
-        "temporarily",
-        "http error 5",
-        "remote end closed",
-    ),
-    DownloadErrorKind.EXTRACTION: (
-        "rehydration",
-        "universal data",
-        "unable to extract",
-        "unable to download webpage",
-        "challenge",
-    ),
-}
-
-# Kinds where retrying has a real chance of succeeding.
-_RETRIABLE_KINDS = frozenset(
-    {
-        DownloadErrorKind.NETWORK,
-        DownloadErrorKind.EXTRACTION,
-        DownloadErrorKind.RATE_LIMITED,
-    }
-)
-
-# User-facing (Ukrainian) message per kind. UNKNOWN falls back to the raw error.
-_ERROR_USER_MESSAGES = {
-    DownloadErrorKind.AGE_RESTRICTED: (
-        "🔞 Відео з віковим обмеженням — сайт вимагає вхід/підтвердження віку, "
-        "тож завантажити не вдалося."
-    ),
-    DownloadErrorKind.LOGIN_REQUIRED: (
-        "🔒 Відео приватне або потребує входу — завантажити не можу."
-    ),
-    DownloadErrorKind.UNAVAILABLE: (
-        "🚫 Відео недоступне (видалене, приватне або не існує)."
-    ),
-    DownloadErrorKind.GEO_BLOCKED: "🌍 Відео недоступне у цьому регіоні.",
-    DownloadErrorKind.RATE_LIMITED: (
-        "⏳ Забагато запитів до сайту. Спробуй, будь ласка, трохи згодом."
-    ),
-    DownloadErrorKind.UNSUPPORTED: "❓ Це посилання не підтримується.",
-    DownloadErrorKind.NETWORK: (
-        "📡 Проблема з мережею під час завантаження. Спробуй ще раз."
-    ),
-    DownloadErrorKind.EXTRACTION: (
-        "⚠️ Сайт тимчасово не віддає відео. Спробуй ще раз за хвилину."
-    ),
-}
-
-
-def classify_download_error(msg: str) -> DownloadErrorKind:
-    """Map a yt-dlp error message to a DownloadErrorKind (first match wins)."""
-    low = msg.lower()
-    for kind, markers in _ERROR_KIND_MARKERS.items():
-        if any(marker in low for marker in markers):
-            return kind
-    return DownloadErrorKind.UNKNOWN
-
-
-def _is_retriable_error(msg: str) -> bool:
-    """True if the error is a transient kind worth retrying."""
-    return classify_download_error(msg) in _RETRIABLE_KINDS
 
 
 # Network/extractor robustness defaults shared by every yt-dlp call.
@@ -483,7 +355,7 @@ class Bot_Func:
                         with yt_dlp.YoutubeDL(opts) as ydl:
                             return ydl.extract_info(med_url, download=True)
                     except yt_dlp.utils.DownloadError as e:
-                        if attempt >= MAX_DOWNLOAD_ATTEMPTS or not _is_retriable_error(
+                        if attempt >= MAX_DOWNLOAD_ATTEMPTS or not is_retriable_error(
                             str(e)
                         ):
                             raise
@@ -558,7 +430,7 @@ class Bot_Func:
             )
             if strt_dwn_msg:
                 await strt_dwn_msg.delete()
-            await user_msg.reply(_ERROR_USER_MESSAGES.get(kind, f"Download error: {e}"))
+            await user_msg.reply(ERROR_USER_MESSAGES.get(kind, f"Download error: {e}"))
             return
         except Exception as e:
             self.log.error(f"❌ An error occurred: {e}")

--- a/src/bot.py
+++ b/src/bot.py
@@ -4,6 +4,7 @@ import contextlib
 import glob
 import json
 import re
+from enum import Enum
 from datetime import datetime
 from pathlib import Path
 import yt_dlp
@@ -22,27 +23,162 @@ LIMIT_SIZE_UPL_VIDEO = 49
 MAX_DOWNLOAD_ATTEMPTS = 4
 RETRY_BASE_DELAY = 1.5
 
-# Substrings that mark a *temporary* failure worth retrying. Anything else
-# (private/removed video, unsupported URL, ...) fails immediately.
-_RETRIABLE_MARKERS = (
-    "rehydration",
-    "universal data",
-    "unable to extract",
-    "unable to download webpage",
-    "challenge",
-    "timed out",
-    "timeout",
-    "connection",
-    "temporarily",
-    "http error 5",
-    "read timed out",
+class DownloadErrorKind(Enum):
+    """Category of a yt-dlp download failure, inferred from its error text.
+
+    Drives three things: whether we retry (transient kinds only), what message
+    the user sees, and how the failure is tagged in logs/download_issues.jsonl.
+    """
+
+    AGE_RESTRICTED = "age_restricted"  # site wants sign-in to confirm age
+    LOGIN_REQUIRED = "login_required"  # private / sign-in / bot-check
+    UNAVAILABLE = "unavailable"  # removed / deleted / private / not found
+    GEO_BLOCKED = "geo_blocked"  # not available in this country
+    RATE_LIMITED = "rate_limited"  # HTTP 429 / too many requests
+    UNSUPPORTED = "unsupported"  # unsupported URL / no extractor / no formats
+    NETWORK = "network"  # timeout / connection / 5xx (transient)
+    EXTRACTION = "extraction"  # rehydration / "unable to extract" (flaky)
+    UNKNOWN = "unknown"  # anything we could not classify
+
+
+# Ordered most-specific → most-generic: the first kind with a matching
+# substring wins, so AGE/LOGIN/UNAVAILABLE are checked before the broad
+# EXTRACTION markers. Match is a case-insensitive substring of the message.
+_ERROR_KIND_MARKERS: tuple[tuple[DownloadErrorKind, tuple[str, ...]], ...] = (
+    (
+        DownloadErrorKind.AGE_RESTRICTED,
+        (
+            "confirm your age",
+            "age-restricted",
+            "age restricted",
+            "inappropriate for some users",
+        ),
+    ),
+    (
+        DownloadErrorKind.LOGIN_REQUIRED,
+        (
+            "sign in to confirm you're not a bot",
+            "sign in",
+            "log in to",
+            "login required",
+            "requires authentication",
+            "private video",
+            "this video is private",
+            "this account is private",
+            "use --cookies",
+        ),
+    ),
+    (
+        DownloadErrorKind.GEO_BLOCKED,
+        (
+            "not available in your country",
+            "in your country",
+            "geo restricted",
+            "geo-restricted",
+        ),
+    ),
+    (
+        DownloadErrorKind.RATE_LIMITED,
+        ("http error 429", "too many requests", "rate-limit", "rate limit"),
+    ),
+    (
+        DownloadErrorKind.UNAVAILABLE,
+        (
+            "video unavailable",
+            "no longer available",
+            "has been removed",
+            "was deleted",
+            "this post may not be available",
+            "http error 404",
+            "account has been terminated",
+        ),
+    ),
+    (
+        DownloadErrorKind.UNSUPPORTED,
+        (
+            "unsupported url",
+            "no suitable extractor",
+            "no video formats found",
+            "is not a valid url",
+        ),
+    ),
+    (
+        DownloadErrorKind.NETWORK,
+        (
+            "timed out",
+            "timeout",
+            "read timed out",
+            "connection",
+            "temporarily",
+            "http error 5",
+            "remote end closed",
+        ),
+    ),
+    (
+        DownloadErrorKind.EXTRACTION,
+        (
+            "rehydration",
+            "universal data",
+            "unable to extract",
+            "unable to download webpage",
+            "challenge",
+        ),
+    ),
 )
+
+# Kinds where retrying has a real chance of succeeding.
+_RETRIABLE_KINDS = frozenset(
+    {
+        DownloadErrorKind.NETWORK,
+        DownloadErrorKind.EXTRACTION,
+        DownloadErrorKind.RATE_LIMITED,
+    }
+)
+
+# User-facing (Ukrainian) message per kind. UNKNOWN falls back to the raw error.
+_ERROR_USER_MESSAGES = {
+    DownloadErrorKind.AGE_RESTRICTED: (
+        "🔞 Відео з віковим обмеженням — сайт вимагає вхід/підтвердження віку, "
+        "тож завантажити не вдалося."
+    ),
+    DownloadErrorKind.LOGIN_REQUIRED: (
+        "🔒 Відео приватне або потребує входу — завантажити не можу."
+    ),
+    DownloadErrorKind.UNAVAILABLE: (
+        "🚫 Відео недоступне (видалене, приватне або не існує)."
+    ),
+    DownloadErrorKind.GEO_BLOCKED: "🌍 Відео недоступне у цьому регіоні.",
+    DownloadErrorKind.RATE_LIMITED: (
+        "⏳ Забагато запитів до сайту. Спробуй, будь ласка, трохи згодом."
+    ),
+    DownloadErrorKind.UNSUPPORTED: "❓ Це посилання не підтримується.",
+    DownloadErrorKind.NETWORK: (
+        "📡 Проблема з мережею під час завантаження. Спробуй ще раз."
+    ),
+    DownloadErrorKind.EXTRACTION: (
+        "⚠️ Сайт тимчасово не віддає відео. Спробуй ще раз за хвилину."
+    ),
+}
+
+
+def classify_download_error(msg: str) -> DownloadErrorKind:
+    """Map a yt-dlp error message to a DownloadErrorKind (first match wins)."""
+    low = msg.lower()
+    for kind, markers in _ERROR_KIND_MARKERS:
+        if any(marker in low for marker in markers):
+            return kind
+    return DownloadErrorKind.UNKNOWN
 
 
 def _is_retriable_error(msg: str) -> bool:
-    """True if the yt-dlp error message looks like a transient, retriable one."""
-    low = msg.lower()
-    return any(marker in low for marker in _RETRIABLE_MARKERS)
+    """True if the error is a transient kind worth retrying."""
+    return classify_download_error(msg) in _RETRIABLE_KINDS
+
+
+def _user_message_for_error(error) -> str:
+    """A friendly, kind-aware Ukrainian message for a download error."""
+    kind = classify_download_error(str(error))
+    return _ERROR_USER_MESSAGES.get(kind, f"Download error: {error}")
 
 
 # Network/extractor robustness defaults shared by every yt-dlp call.
@@ -263,6 +399,7 @@ class Bot_Func:
                 "reason": reason,
                 "url": url,
                 "error": str(error) if error else None,
+                "kind": classify_download_error(str(error)).value if error else None,
                 "user_id": user_id,
                 "chat_id": chat_id,
                 "yt_dlp": getattr(getattr(yt_dlp, "version", None), "__version__", "?"),
@@ -423,7 +560,7 @@ class Bot_Func:
             self.log.success(f"✅ Download successful! {loc_video}")
             self._log_media_info(media_info)
         except yt_dlp.utils.DownloadError as e:
-            self.log.error(f"❌ Download error: {e}")
+            self.log.error(f"❌ Download error [{classify_download_error(str(e)).value}]: {e}")
             self._record_download_issue(
                 med_url,
                 "download_error",
@@ -434,7 +571,7 @@ class Bot_Func:
             )
             if strt_dwn_msg:
                 await strt_dwn_msg.delete()
-            await user_msg.reply(f"Download error: {e}")
+            await user_msg.reply(_user_message_for_error(e))
             return
         except Exception as e:
             self.log.error(f"❌ An error occurred: {e}")

--- a/src/bot.py
+++ b/src/bot.py
@@ -44,87 +44,68 @@ class DownloadErrorKind(Enum):
 # Ordered most-specific → most-generic: the first kind with a matching
 # substring wins, so AGE/LOGIN/UNAVAILABLE are checked before the broad
 # EXTRACTION markers. Match is a case-insensitive substring of the message.
-_ERROR_KIND_MARKERS: tuple[tuple[DownloadErrorKind, tuple[str, ...]], ...] = (
-    (
-        DownloadErrorKind.AGE_RESTRICTED,
-        (
-            "confirm your age",
-            "age-restricted",
-            "age restricted",
-            "inappropriate for some users",
-        ),
+_ERROR_KIND_MARKERS: dict[DownloadErrorKind, tuple[str, ...]] = {
+    DownloadErrorKind.AGE_RESTRICTED: (
+        "confirm your age",
+        "age-restricted",
+        "age restricted",
+        "inappropriate for some users",
     ),
-    (
-        DownloadErrorKind.LOGIN_REQUIRED,
-        (
-            "sign in to confirm you're not a bot",
-            "sign in",
-            "log in to",
-            "login required",
-            "requires authentication",
-            "private video",
-            "this video is private",
-            "this account is private",
-            "use --cookies",
-        ),
+    DownloadErrorKind.LOGIN_REQUIRED: (
+        "sign in to confirm you're not a bot",
+        "sign in",
+        "log in to",
+        "login required",
+        "requires authentication",
+        "private video",
+        "this video is private",
+        "this account is private",
+        "use --cookies",
     ),
-    (
-        DownloadErrorKind.GEO_BLOCKED,
-        (
-            "not available in your country",
-            "in your country",
-            "geo restricted",
-            "geo-restricted",
-        ),
+    DownloadErrorKind.GEO_BLOCKED: (
+        "not available in your country",
+        "in your country",
+        "geo restricted",
+        "geo-restricted",
     ),
-    (
-        DownloadErrorKind.RATE_LIMITED,
-        ("http error 429", "too many requests", "rate-limit", "rate limit"),
+    DownloadErrorKind.RATE_LIMITED: (
+        "http error 429",
+        "too many requests",
+        "rate-limit",
+        "rate limit",
     ),
-    (
-        DownloadErrorKind.UNAVAILABLE,
-        (
-            "video unavailable",
-            "no longer available",
-            "has been removed",
-            "was deleted",
-            "this post may not be available",
-            "http error 404",
-            "account has been terminated",
-        ),
+    DownloadErrorKind.UNAVAILABLE: (
+        "video unavailable",
+        "no longer available",
+        "has been removed",
+        "was deleted",
+        "this post may not be available",
+        "http error 404",
+        "account has been terminated",
     ),
-    (
-        DownloadErrorKind.UNSUPPORTED,
-        (
-            "unsupported url",
-            "no suitable extractor",
-            "no video formats found",
-            "is not a valid url",
-        ),
+    DownloadErrorKind.UNSUPPORTED: (
+        "unsupported url",
+        "no suitable extractor",
+        "no video formats found",
+        "is not a valid url",
     ),
-    (
-        DownloadErrorKind.NETWORK,
-        (
-            "timed out",
-            "timeout",
-            "read timed out",
-            "connection",
-            "temporarily",
-            "http error 5",
-            "remote end closed",
-        ),
+    DownloadErrorKind.NETWORK: (
+        "timed out",
+        "timeout",
+        "read timed out",
+        "connection",
+        "temporarily",
+        "http error 5",
+        "remote end closed",
     ),
-    (
-        DownloadErrorKind.EXTRACTION,
-        (
-            "rehydration",
-            "universal data",
-            "unable to extract",
-            "unable to download webpage",
-            "challenge",
-        ),
+    DownloadErrorKind.EXTRACTION: (
+        "rehydration",
+        "universal data",
+        "unable to extract",
+        "unable to download webpage",
+        "challenge",
     ),
-)
+}
 
 # Kinds where retrying has a real chance of succeeding.
 _RETRIABLE_KINDS = frozenset(
@@ -164,7 +145,7 @@ _ERROR_USER_MESSAGES = {
 def classify_download_error(msg: str) -> DownloadErrorKind:
     """Map a yt-dlp error message to a DownloadErrorKind (first match wins)."""
     low = msg.lower()
-    for kind, markers in _ERROR_KIND_MARKERS:
+    for kind, markers in _ERROR_KIND_MARKERS.items():
         if any(marker in low for marker in markers):
             return kind
     return DownloadErrorKind.UNKNOWN
@@ -173,12 +154,6 @@ def classify_download_error(msg: str) -> DownloadErrorKind:
 def _is_retriable_error(msg: str) -> bool:
     """True if the error is a transient kind worth retrying."""
     return classify_download_error(msg) in _RETRIABLE_KINDS
-
-
-def _user_message_for_error(error) -> str:
-    """A friendly, kind-aware Ukrainian message for a download error."""
-    kind = classify_download_error(str(error))
-    return _ERROR_USER_MESSAGES.get(kind, f"Download error: {error}")
 
 
 # Network/extractor robustness defaults shared by every yt-dlp call.
@@ -384,14 +359,24 @@ class Bot_Func:
         return ""
 
     def _record_download_issue(
-        self, url, reason, media_info=None, error=None, chat_id=None, user_id=None
+        self,
+        url,
+        reason,
+        media_info=None,
+        error=None,
+        chat_id=None,
+        user_id=None,
+        kind=None,
     ) -> None:
         """Append a JSONL record (logs/download_issues.jsonl) for a failed or
         audioless download, so the problem can be understood and reproduced.
 
         ``chat_id`` is where it happened (may be a group); ``user_id`` is who
-        triggered it (the real person, passed in by the handler)."""
+        triggered it (the real person, passed in by the handler). ``kind`` is the
+        pre-classified DownloadErrorKind; if omitted it's derived from ``error``."""
         try:
+            if kind is None and error is not None:
+                kind = classify_download_error(str(error))
             vcodec, acodec = _codecs_of(media_info)
             src = _source_stream_dict(media_info)
             record = {
@@ -399,7 +384,7 @@ class Bot_Func:
                 "reason": reason,
                 "url": url,
                 "error": str(error) if error else None,
-                "kind": classify_download_error(str(error)).value if error else None,
+                "kind": kind.value if kind else None,
                 "user_id": user_id,
                 "chat_id": chat_id,
                 "yt_dlp": getattr(getattr(yt_dlp, "version", None), "__version__", "?"),
@@ -560,7 +545,8 @@ class Bot_Func:
             self.log.success(f"✅ Download successful! {loc_video}")
             self._log_media_info(media_info)
         except yt_dlp.utils.DownloadError as e:
-            self.log.error(f"❌ Download error [{classify_download_error(str(e)).value}]: {e}")
+            kind = classify_download_error(str(e))
+            self.log.error(f"❌ Download error [{kind.value}]: {e}")
             self._record_download_issue(
                 med_url,
                 "download_error",
@@ -568,10 +554,11 @@ class Bot_Func:
                 error=e,
                 chat_id=chat_id,
                 user_id=user_id,
+                kind=kind,
             )
             if strt_dwn_msg:
                 await strt_dwn_msg.delete()
-            await user_msg.reply(_user_message_for_error(e))
+            await user_msg.reply(_ERROR_USER_MESSAGES.get(kind, f"Download error: {e}"))
             return
         except Exception as e:
             self.log.error(f"❌ An error occurred: {e}")

--- a/src/download_errors.py
+++ b/src/download_errors.py
@@ -1,0 +1,140 @@
+"""Classification of yt-dlp download failures.
+
+Pure, dependency-free logic (no yt-dlp / aiogram imports) so it can be unit
+tested in isolation. ``src.bot`` imports the public names from here.
+"""
+
+from enum import Enum
+
+
+class DownloadErrorKind(Enum):
+    """Category of a yt-dlp download failure, inferred from its error text.
+
+    Drives three things: whether we retry (transient kinds only), what message
+    the user sees, and how the failure is tagged in logs/download_issues.jsonl.
+    """
+
+    AGE_RESTRICTED = "age_restricted"  # site wants sign-in to confirm age
+    LOGIN_REQUIRED = "login_required"  # private / sign-in / bot-check
+    UNAVAILABLE = "unavailable"  # removed / deleted / private / not found
+    GEO_BLOCKED = "geo_blocked"  # not available in this country
+    RATE_LIMITED = "rate_limited"  # HTTP 429 / too many requests
+    UNSUPPORTED = "unsupported"  # unsupported URL / no extractor / no formats
+    NETWORK = "network"  # timeout / connection / 5xx (transient)
+    EXTRACTION = "extraction"  # rehydration / "unable to extract" (flaky)
+    UNKNOWN = "unknown"  # anything we could not classify
+
+
+# Ordered most-specific → most-generic: the first kind with a matching
+# substring wins, so AGE/LOGIN/UNAVAILABLE are checked before the broad
+# EXTRACTION markers. Match is a case-insensitive substring of the message.
+_ERROR_KIND_MARKERS: dict[DownloadErrorKind, tuple[str, ...]] = {
+    DownloadErrorKind.AGE_RESTRICTED: (
+        "confirm your age",
+        "age-restricted",
+        "age restricted",
+        "inappropriate for some users",
+    ),
+    DownloadErrorKind.LOGIN_REQUIRED: (
+        "sign in to confirm you're not a bot",
+        "sign in",
+        "log in to",
+        "login required",
+        "requires authentication",
+        "private video",
+        "this video is private",
+        "this account is private",
+        "use --cookies",
+    ),
+    DownloadErrorKind.GEO_BLOCKED: (
+        "not available in your country",
+        "in your country",
+        "geo restricted",
+        "geo-restricted",
+    ),
+    DownloadErrorKind.RATE_LIMITED: (
+        "http error 429",
+        "too many requests",
+        "rate-limit",
+        "rate limit",
+    ),
+    DownloadErrorKind.UNAVAILABLE: (
+        "video unavailable",
+        "no longer available",
+        "has been removed",
+        "was deleted",
+        "this post may not be available",
+        "http error 404",
+        "account has been terminated",
+    ),
+    DownloadErrorKind.UNSUPPORTED: (
+        "unsupported url",
+        "no suitable extractor",
+        "no video formats found",
+        "is not a valid url",
+    ),
+    DownloadErrorKind.NETWORK: (
+        "timed out",  # also covers "read timed out"
+        "timeout",
+        "connection",
+        "temporarily",
+        "http error 5",
+        "remote end closed",
+    ),
+    DownloadErrorKind.EXTRACTION: (
+        "rehydration",
+        "universal data",
+        "unable to extract",
+        "unable to download webpage",
+        "challenge",
+    ),
+}
+
+# Kinds where retrying has a real chance of succeeding.
+_RETRIABLE_KINDS = frozenset(
+    {
+        DownloadErrorKind.NETWORK,
+        DownloadErrorKind.EXTRACTION,
+        DownloadErrorKind.RATE_LIMITED,
+    }
+)
+
+# User-facing (Ukrainian) message per kind. Kinds absent here (e.g. UNKNOWN)
+# fall back to the raw error text at the call site.
+ERROR_USER_MESSAGES = {
+    DownloadErrorKind.AGE_RESTRICTED: (
+        "🔞 Відео з віковим обмеженням — сайт вимагає вхід/підтвердження віку, "
+        "тож завантажити не вдалося."
+    ),
+    DownloadErrorKind.LOGIN_REQUIRED: (
+        "🔒 Відео приватне або потребує входу — завантажити не можу."
+    ),
+    DownloadErrorKind.UNAVAILABLE: (
+        "🚫 Відео недоступне (видалене, приватне або не існує)."
+    ),
+    DownloadErrorKind.GEO_BLOCKED: "🌍 Відео недоступне у цьому регіоні.",
+    DownloadErrorKind.RATE_LIMITED: (
+        "⏳ Забагато запитів до сайту. Спробуй, будь ласка, трохи згодом."
+    ),
+    DownloadErrorKind.UNSUPPORTED: "❓ Це посилання не підтримується.",
+    DownloadErrorKind.NETWORK: (
+        "📡 Проблема з мережею під час завантаження. Спробуй ще раз."
+    ),
+    DownloadErrorKind.EXTRACTION: (
+        "⚠️ Сайт тимчасово не віддає відео. Спробуй ще раз за хвилину."
+    ),
+}
+
+
+def classify_download_error(msg: str) -> DownloadErrorKind:
+    """Map a yt-dlp error message to a DownloadErrorKind (first match wins)."""
+    low = msg.lower()
+    for kind, markers in _ERROR_KIND_MARKERS.items():
+        if any(marker in low for marker in markers):
+            return kind
+    return DownloadErrorKind.UNKNOWN
+
+
+def is_retriable_error(msg: str) -> bool:
+    """True if the error is a transient kind worth retrying."""
+    return classify_download_error(msg) in _RETRIABLE_KINDS

--- a/tests/test_download_errors.py
+++ b/tests/test_download_errors.py
@@ -1,0 +1,102 @@
+"""Unit tests for src.download_errors.
+
+Pure logic — no yt-dlp / aiogram needed, so this runs standalone:
+    python tests/test_download_errors.py
+or under pytest:
+    pytest tests/test_download_errors.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.download_errors import (  # noqa: E402
+    DownloadErrorKind,
+    ERROR_USER_MESSAGES,
+    _ERROR_KIND_MARKERS,
+    classify_download_error,
+    is_retriable_error,
+)
+
+K = DownloadErrorKind
+
+# (yt-dlp-style message, expected kind, expected retriable)
+CASES = [
+    # The bot's real flaky error — must stay retriable.
+    (
+        "ERROR: [TikTok] 1: Unable to extract universal data for rehydration; "
+        "please report this issue on https://github.com/yt-dlp/yt-dlp/issues",
+        K.EXTRACTION,
+        True,
+    ),
+    (
+        "ERROR: Sign in to confirm your age. This video may be inappropriate "
+        "for some users.",
+        K.AGE_RESTRICTED,
+        False,
+    ),
+    ("ERROR: Sign in to confirm you're not a bot", K.LOGIN_REQUIRED, False),
+    ("ERROR: [instagram] This account is private", K.LOGIN_REQUIRED, False),
+    ("ERROR: Video unavailable. This video has been removed", K.UNAVAILABLE, False),
+    (
+        "ERROR: The uploader has not made this video available in your country",
+        K.GEO_BLOCKED,
+        False,
+    ),
+    ("ERROR: HTTP Error 429: Too Many Requests", K.RATE_LIMITED, True),
+    ("ERROR: Unsupported URL: https://example.com/x", K.UNSUPPORTED, False),
+    ("ERROR: Unable to download webpage: Read timed out.", K.NETWORK, True),
+    ("ERROR: <urlopen error [Errno 111] Connection refused>", K.NETWORK, True),
+    ("ERROR: HTTP Error 503: Service Unavailable", K.NETWORK, True),
+    ("ERROR: something we have never seen before", K.UNKNOWN, False),
+]
+
+
+def test_classification_and_retriability():
+    for msg, kind, retriable in CASES:
+        assert classify_download_error(msg) == kind, (msg, classify_download_error(msg))
+        assert is_retriable_error(msg) is retriable, (msg, is_retriable_error(msg))
+
+
+def test_case_insensitive():
+    assert classify_download_error("UNABLE TO EXTRACT something") == K.EXTRACTION
+
+
+def test_specific_kind_wins_over_later_generic():
+    # Ordering is load-bearing: a permanent AGE marker must win even though the
+    # message also contains a later EXTRACTION substring ("extract").
+    msg = "Sign in to confirm your age — also could not extract the page"
+    assert classify_download_error(msg) == K.AGE_RESTRICTED
+    assert is_retriable_error(msg) is False
+
+
+def test_read_timed_out_still_classifies_as_network():
+    # "read timed out" was removed as redundant; "timed out" still covers it.
+    assert classify_download_error("Read timed out.") == K.NETWORK
+
+
+def test_every_kind_except_unknown_has_markers_and_a_message():
+    for kind in DownloadErrorKind:
+        if kind is DownloadErrorKind.UNKNOWN:
+            continue
+        assert kind in _ERROR_KIND_MARKERS, f"{kind} has no markers"
+        assert kind in ERROR_USER_MESSAGES, f"{kind} has no user message"
+
+
+if __name__ == "__main__":
+    import traceback
+
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_"):
+            continue
+        try:
+            fn()
+            print(f"PASS  {name}")
+        except Exception:  # noqa: BLE001
+            failures += 1
+            print(f"FAIL  {name}")
+            traceback.print_exc()
+    print("ALL PASS" if not failures else f"{failures} TEST(S) FAILED")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Контекст

Раніше всі помилки yt-dlp оброблялись однаково: булеве «ретраїти чи ні» (`_RETRIABLE_MARKERS`) + сирий текст помилки користувачу. Цей PR класифікує помилки в **enum категорій**, щоб: (1) точніше вирішувати, чи ретраїти, (2) показувати користувачу **зрозуміле повідомлення** (зокрема для відео з **віковим обмеженням** / приватних / гео-блоку), (3) тегувати збій у `logs/download_issues.jsonl` для діагностики.

## Що нового

**`src/download_errors.py`** — нова чиста, тестовно-ізольована логіка (без `yt_dlp`/`aiogram`):

| Kind | Приклад повідомлення yt-dlp | Retriable? |
|------|------------------------------|:----------:|
| `AGE_RESTRICTED` | «Sign in to confirm your age» | ні |
| `LOGIN_REQUIRED` | «Sign in to confirm you're not a bot», «This account is private» | ні |
| `UNAVAILABLE` | «Video unavailable», «HTTP Error 404» | ні |
| `GEO_BLOCKED` | «not available in your country» | ні |
| `RATE_LIMITED` | «HTTP Error 429» | так |
| `UNSUPPORTED` | «Unsupported URL» | ні |
| `NETWORK` | «Read timed out», «Connection refused», «HTTP Error 503» | так |
| `EXTRACTION` | «Unable to extract universal data for rehydration» (flaky TikTok) | так |
| `UNKNOWN` | — | ні |

- `classify_download_error(msg)` — ordered first-match-wins (специфічні категорії перед загальними).
- `is_retriable_error(msg)` = `kind in {NETWORK, EXTRACTION, RATE_LIMITED}` — стара retry-поведінка збережена, додано лише 429.
- При помилці користувач бачить дружнє укр-повідомлення per-kind замість сирого тексту yt-dlp.
- `logs/download_issues.jsonl` пише поле `kind`.

**`tests/test_download_errors.py`** — перший юніт-тест у проєкті:
- класифікація + retriable для реальної rehydration-помилки й кожної категорії;
- case-insensitivity;
- **порядок** (специфічна категорія перемагає пізніший загальний підрядок);
- completeness — кожна категорія (крім UNKNOWN) має маркери і повідомлення.
- Запускається standalone (`python tests/test_download_errors.py`) і під pytest.

## Перевірка
- `compileall` + `ruff` — зелено.
- 5/5 тестів проходять.
- Пройдено `/simplify` (класифікація раз; markers як dict; винесення хелперів) і `/code-review` (high; реальних багів нема, прибрано лише мертвий маркер `read timed out`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)