### PR TITLE
Класифікація помилок (DownloadErrorKind + тести) → dev (підтягує dev до master)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,6 @@ assets
 **/*test*.py
 data/reg_user.csv
 .vscode
+
+# Project unit tests are versioned (override the generic *test*.py rules above)
+!tests/**/*.py

--- a/handlers/media_bot.py
+++ b/handlers/media_bot.py
@@ -29,6 +29,7 @@ _YDL_OPTS_BY_MODE = {
             "/bestvideo[ext=mp4]+bestaudio[ext=m4a]"
             "/bestvideo+bestaudio/best"
         ),
+        "format_sort": ["vcodec:h264"],
         "merge_output_format": "mp4",
     },
 }

--- a/handlers/media_bot.py
+++ b/handlers/media_bot.py
@@ -9,21 +9,27 @@ from src import utils as ut
 router_med = Router()
 
 _YDL_OPTS_BY_MODE = {
-    'audio': {
-        'format': 'bestaudio/best',
-        'postprocessors': [{
-            'key': 'FFmpegExtractAudio',
-            'preferredcodec': 'mp3',
-            'preferredquality': '192',
-        }],
+    "audio": {
+        "format": "bestaudio/best",
+        "postprocessors": [
+            {
+                "key": "FFmpegExtractAudio",
+                "preferredcodec": "mp3",
+                "preferredquality": "192",
+            }
+        ],
     },
-    'video': {
-        'format': 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best',
-        'merge_output_format': 'mp4',
+    "video": {
+        "format": "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
+        "merge_output_format": "mp4",
     },
-    'social': {
-        'format': 'bestvideo+bestaudio/best',
-        'merge_output_format': 'mp4',
+    "social": {
+        "format": (
+            "bestvideo[vcodec^=avc1]+bestaudio[ext=m4a]"
+            "/bestvideo[ext=mp4]+bestaudio[ext=m4a]"
+            "/bestvideo+bestaudio/best"
+        ),
+        "merge_output_format": "mp4",
     },
 }
 
@@ -33,11 +39,12 @@ _CAPTION_TEMPLATE = jinja2.Environment().from_string(
 # BOT_NAME = 'med_soc_bot'
 
 
-
 # @dp.callback_query(CommonParamYouTube.filter(F.vid_data == "vid_140"))
 # @dp.callback_query(CommonParamYouTube.filter(F.vid_data.startwith("vid")))
 @router_med.callback_query(F.data.startswith("vid"))
-async def handle_callback(callback_query: types.CallbackQuery, logger, user_data, bot_func, cfg):
+async def handle_callback(
+    callback_query: types.CallbackQuery, logger, user_data, bot_func, cfg
+):
     cb1 = CommonParamYouTube.unpack(callback_query.data)
     title = cb1.title
     environment = jinja2.Environment()
@@ -49,9 +56,9 @@ async def handle_callback(callback_query: types.CallbackQuery, logger, user_data
     if ut.is_ltn(title):
         ...
     vid_dt = cb1.vid_data
-    logger.trace(f'{cb1=}')
-    format_id = vid_dt.split('_')[1]
-    
+    logger.trace(f"{cb1=}")
+    format_id = vid_dt.split("_")[1]
+
     user_bot = callback_query.from_user
     youtube_url = user_data.get(user_bot.id)  # Retrieve the saved link
     bot_msg = callback_query.message
@@ -66,83 +73,88 @@ async def handle_callback(callback_query: types.CallbackQuery, logger, user_data
 
     total_mem_user_level = user.level.value
     used_memory_per_user = user.use_memory
-    available_memory = total_mem_user_level - used_memory_per_user  
-    progress_bar_str_value = ut.progress_bar_str(used_memory_per_user, total_mem_user_level)
+    available_memory = total_mem_user_level - used_memory_per_user
+    progress_bar_str_value = ut.progress_bar_str(
+        used_memory_per_user, total_mem_user_level
+    )
 
     current_date = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     # TODO: loc video must to be with real name
-    full_name_video = current_date +'__'+ title
+    full_name_video = current_date + "__" + title
     loc_media = f"media/{user.id}/{full_name_video}.%(ext)s"
 
     # Options for yt-dlp without post-processing
     ydl_opts = {
-        # 'format': f'{format_id}+bestaudio/best[ext=m4a]',  # Combine video format with best audio  
-        # #'format': 'bestvideo[ext=mp4]+bestaudio[ext=mp4]/mp4+best[height<=480]', 
-        'format': f'{format_id}+bestaudio[ext=m4a]/{format_id}+bestaudio/best',
-        'outtmpl': loc_media,
+        # 'format': f'{format_id}+bestaudio/best[ext=m4a]',  # Combine video format with best audio
+        # #'format': 'bestvideo[ext=mp4]+bestaudio[ext=mp4]/mp4+best[height<=480]',
+        "format": f"{format_id}+bestaudio[ext=m4a]/{format_id}+bestaudio/best",
+        "outtmpl": loc_media,
         # 'outtmpl': '%(title)s.%(ext)s'
     }
 
     res = await bot_func.get_dwn_media(ydl_opts, bot_msg, youtubeLink=youtube_url)
     if not res:
-        await bot_msg.answer('Не вдалося завантажити. Перевір посилання і спробуй ще раз.')
-        logger.warning(f'Failed to download media with link {youtube_url}\n\n\n')
+        await bot_msg.answer(
+            "Не вдалося завантажити. Перевір посилання і спробуй ще раз."
+        )
+        logger.warning(f"Failed to download media with link {youtube_url}\n\n\n")
         return
     loc_media, file_size = res
-    info_wait_button = await bot_msg.reply("✅ Download successful!\nSending video", disable_notification=True)
+    info_wait_button = await bot_msg.reply(
+        "✅ Download successful!\nSending video", disable_notification=True
+    )
     # loc_match = glob.glob(os.path.join('.', f'{loc_media}*'))
     # assert loc_match
     # loc_video  = loc_match[0]
     answer_cap = answer_template.render(
-        bot_name = cfg.shared_vars.bot_name, 
-        avail_mem = ut.h_readable(available_memory-file_size),
-        progress_bar_str_value = progress_bar_str_value,
-        youtube_url = youtube_url,
-        name = title)
+        bot_name=cfg.shared_vars.bot_name,
+        avail_mem=ut.h_readable(available_memory - file_size),
+        progress_bar_str_value=progress_bar_str_value,
+        youtube_url=youtube_url,
+        name=title,
+    )
     try:
         ext = os.path.splitext(loc_media)[1].lower()
-        if ext in ('.mp4', '.mkv', '.webm'):
-            logger.info(f'Sending as video: {loc_media}')
+        if ext in (".mp4", ".mkv", ".webm"):
+            logger.info(f"Sending as video: {loc_media}")
             await bot_msg.answer_video(
-                                        video=types.FSInputFile(loc_media),
-                                        caption=answer_cap,
-                                        title=title)
+                video=types.FSInputFile(loc_media), caption=answer_cap, title=title
+            )
         else:
-            logger.info(f'Sending as audio: {loc_media}')
-            await bot_msg.answer_audio(audio=types.FSInputFile(loc_media),
-                                    caption = f'@{cfg.shared_vars.bot_name}',
-                                    title=title)
+            logger.info(f"Sending as audio: {loc_media}")
+            await bot_msg.answer_audio(
+                audio=types.FSInputFile(loc_media),
+                caption=f"@{cfg.shared_vars.bot_name}",
+                title=title,
+            )
         # If audio only send message.answer_musick or answer_audio check it
         # ut.recalc_used_mem(loc_video, user)
         user.use_memory += file_size
         ut.update_row(user)
     except Exception as e:
         await bot_msg.reply(f"An error occurred while sending the video: {e}")
-    
-    
-    ut.delete_video_file(loc_media)
-    
 
+    ut.delete_video_file(loc_media)
 
     await bot_msg.delete()
     await info_wait_button.delete()
 
 
-
-
 @router_med.callback_query(F.data.startswith("idl"))
-async def handle_inline_download(callback_query: types.CallbackQuery, logger, user_data, bot_func, cfg, bot: Bot):
+async def handle_inline_download(
+    callback_query: types.CallbackQuery, logger, user_data, bot_func, cfg, bot: Bot
+):
     cb = CommonParamInline.unpack(callback_query.data)
     data = user_data.get(cb.key)
-    logger.info(f'Inline download callback: {cb.key=} {data=}')
+    logger.info(f"Inline download callback: {cb.key=} {data=}")
 
     if not data:
         await callback_query.answer("Link expired. Try searching again.")
         return
 
-    url = data['url']
-    mode = data.get('mode', 'social')
-    media_title = data.get('title', '')
+    url = data["url"]
+    mode = data.get("mode", "social")
+    media_title = data.get("title", "")
 
     user_id = callback_query.from_user.id
     df_t = ut.get_user_by_id(user_id)
@@ -161,25 +173,31 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
     inline_msg_id = callback_query.inline_message_id
     if inline_msg_id:
         try:
-            await bot.edit_message_text("Downloading...", inline_message_id=inline_msg_id)
+            await bot.edit_message_text(
+                "Downloading...", inline_message_id=inline_msg_id
+            )
         except Exception as e:
-            logger.debug(f'edit inline status failed: {e}')
+            logger.debug(f"edit inline status failed: {e}")
 
     status_msg = await bot.send_message(user_id, "Start downloading ...")
 
     loc_media = f"media/{user_id}/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
-    ydl_opts = {**_YDL_OPTS_BY_MODE[mode], 'outtmpl': loc_media}
+    ydl_opts = {**_YDL_OPTS_BY_MODE[mode], "outtmpl": loc_media}
 
     res = await bot_func.get_dwn_media(ydl_opts, status_msg, youtubeLink=url)
     await status_msg.delete()
     if not res:
-        await bot.send_message(user_id, 'Не вдалося завантажити. Перевір посилання і спробуй ще раз.')
+        await bot.send_message(
+            user_id, "Не вдалося завантажити. Перевір посилання і спробуй ще раз."
+        )
         if inline_msg_id:
             try:
-                await bot.edit_message_text("Download failed", inline_message_id=inline_msg_id)
+                await bot.edit_message_text(
+                    "Download failed", inline_message_id=inline_msg_id
+                )
             except Exception as e:
-                logger.debug(f'edit inline failure status failed: {e}')
-        logger.warning(f'Failed inline download {url} for user {user_id}')
+                logger.debug(f"edit inline failure status failed: {e}")
+        logger.warning(f"Failed inline download {url} for user {user_id}")
         return
     loc_media, file_size = res
 
@@ -192,12 +210,12 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
     )
 
     try:
-        if mode == 'audio':
+        if mode == "audio":
             dm_msg = await bot.send_audio(
                 chat_id=user_id,
                 audio=types.FSInputFile(loc_media),
                 title=media_title or None,
-                caption=f'@{cfg.shared_vars.bot_name}',
+                caption=f"@{cfg.shared_vars.bot_name}",
             )
         else:
             dm_msg = await bot.send_video(
@@ -207,24 +225,30 @@ async def handle_inline_download(callback_query: types.CallbackQuery, logger, us
             )
 
         if inline_msg_id and dm_msg:
-            if mode == 'audio' and dm_msg.audio:
+            if mode == "audio" and dm_msg.audio:
                 media = types.InputMediaAudio(
                     media=dm_msg.audio.file_id,
-                    caption=f'@{cfg.shared_vars.bot_name}',
+                    caption=f"@{cfg.shared_vars.bot_name}",
                 )
             elif dm_msg.video:
-                media = types.InputMediaVideo(media=dm_msg.video.file_id, caption=answer_cap)
+                media = types.InputMediaVideo(
+                    media=dm_msg.video.file_id, caption=answer_cap
+                )
             elif dm_msg.document:
-                media = types.InputMediaDocument(media=dm_msg.document.file_id, caption=answer_cap)
+                media = types.InputMediaDocument(
+                    media=dm_msg.document.file_id, caption=answer_cap
+                )
             else:
                 media = None
 
             if media:
                 try:
-                    await bot.edit_message_media(media=media, inline_message_id=inline_msg_id)
+                    await bot.edit_message_media(
+                        media=media, inline_message_id=inline_msg_id
+                    )
                     await dm_msg.delete()
                 except Exception as e:
-                    logger.error(f'edit_message_media failed: {e}')
+                    logger.error(f"edit_message_media failed: {e}")
 
     except Exception as e:
         await bot.send_message(user_id, f"Error sending media: {e}")

--- a/handlers/media_bot.py
+++ b/handlers/media_bot.py
@@ -93,7 +93,9 @@ async def handle_callback(
         # 'outtmpl': '%(title)s.%(ext)s'
     }
 
-    res = await bot_func.get_dwn_media(ydl_opts, bot_msg, youtubeLink=youtube_url)
+    res = await bot_func.get_dwn_media(
+        ydl_opts, bot_msg, youtubeLink=youtube_url, user_id=user_bot.id
+    )
     if not res:
         await bot_msg.answer(
             "Не вдалося завантажити. Перевір посилання і спробуй ще раз."
@@ -185,7 +187,9 @@ async def handle_inline_download(
     loc_media = f"media/{user_id}/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.%(ext)s"
     ydl_opts = {**_YDL_OPTS_BY_MODE[mode], "outtmpl": loc_media}
 
-    res = await bot_func.get_dwn_media(ydl_opts, status_msg, youtubeLink=url)
+    res = await bot_func.get_dwn_media(
+        ydl_opts, status_msg, youtubeLink=url, user_id=user_id
+    )
     await status_msg.delete()
     if not res:
         await bot.send_message(

--- a/handlers/media_bot.py
+++ b/handlers/media_bot.py
@@ -182,7 +182,7 @@ async def handle_inline_download(
 
     status_msg = await bot.send_message(user_id, "Start downloading ...")
 
-    loc_media = f"media/{user_id}/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
+    loc_media = f"media/{user_id}/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.%(ext)s"
     ydl_opts = {**_YDL_OPTS_BY_MODE[mode], "outtmpl": loc_media}
 
     res = await bot_func.get_dwn_media(ydl_opts, status_msg, youtubeLink=url)

--- a/handlers/test_bot.py
+++ b/handlers/test_bot.py
@@ -56,38 +56,95 @@ async def check_access(message: types.Message, allowed_levels: list[Level]):
     return user
 
 @router.inline_query()
-async def inline_query_handler(inline_query: types.InlineQuery, logger):
+async def inline_query_handler(inline_query: types.InlineQuery, logger, bot_func):
     query = inline_query.query.strip()
     logger.trace(f'Inline Query: {query=}')
 
     articles = []
 
-    if 'tiktok.com' in query:
-        articles.append(
-            InlineQueryResultArticle(
-                id='1',
-                title="TikTok Download",
-                input_message_content=InputTextMessageContent(message_text="TikTok video is downloading..."),
-                description="Download the video from the provided TikTok link.",
-                reply_markup=types.InlineKeyboardMarkup(
-                    inline_keyboard=[[types.InlineKeyboardButton(
-                        text="Download",
-                        callback_data=CommonParamTick(title="TikTok", vid_data='ticktock_test').pack()
-                    )]]
+    if query.startswith('ssoc ') and len(query) > 5:
+        search_text = query[5:].strip()
+        if not search_text:
+            await inline_query.answer(results=[], cache_time=10)
+            return
+
+        logger.info(f'YouTube search via inline: {search_text}')
+        entries = bot_func.search_youtube(search_text, max_results=5)
+
+        for i, entry in enumerate(entries):
+            title = entry.get('title', 'No title')
+            channel = entry.get('channel', entry.get('uploader', 'Unknown'))
+            duration = entry.get('duration')
+            video_url = entry.get('url', '')
+
+            duration_str = ''
+            if duration:
+                mins, secs = divmod(int(duration), 60)
+                duration_str = f'{mins}:{secs:02d}'
+
+            description_parts = []
+            if duration_str:
+                description_parts.append(duration_str)
+            if channel:
+                description_parts.append(channel)
+            description = ' | '.join(description_parts) if description_parts else 'YouTube video'
+
+            articles.append(
+                InlineQueryResultArticle(
+                    id=str(i),
+                    title=title,
+                    input_message_content=InputTextMessageContent(
+                        message_text=video_url,
+                    ),
+                    description=description,
                 )
             )
-        )
-    else:
+
+        if not articles:
+            articles.append(
+                InlineQueryResultArticle(
+                    id='no_results',
+                    title='No results found',
+                    input_message_content=InputTextMessageContent(
+                        message_text='No YouTube results found.',
+                    ),
+                    description=f'No videos found for "{search_text}"',
+                )
+            )
+
+    elif any(domain in query for domain in ['tiktok.com', 'instagram.com', 'youtube.com', 'youtu.be']):
+        link = query.strip()
+        if 'tiktok.com' in link:
+            label = 'TikTok'
+        elif 'instagram.com' in link:
+            label = 'Instagram'
+        else:
+            label = 'YouTube'
+
         articles.append(
             InlineQueryResultArticle(
-                id='2',
-                title="Invalid Link",
-                input_message_content=InputTextMessageContent(message_text="This link is not supported."),
-                description="The provided link is not supported."
+                id='dl_social',
+                title=f'Download {label} video',
+                input_message_content=InputTextMessageContent(
+                    message_text=link,
+                ),
+                description=f'Download video from {label}',
             )
         )
 
-    await inline_query.answer(results=articles)
+    else:
+        articles.append(
+            InlineQueryResultArticle(
+                id='help',
+                title='How to use',
+                input_message_content=InputTextMessageContent(
+                    message_text='Use @bot ssoc <query> to search YouTube, or paste a TikTok/Instagram/YouTube link.',
+                ),
+                description='ssoc <query> | or paste a social link',
+            )
+        )
+
+    await inline_query.answer(results=articles, cache_time=10)
 
 
 @router.message(Command("test0"))

--- a/justfile
+++ b/justfile
@@ -4,6 +4,12 @@ setup:
     git config --unset-all core.hooksPath || true
     pre-commit install
 
+# Run the bot. Auto-updates yt-dlp first so the TikTok/Instagram/YouTube
+# extractors stay fresh (they break often and are fixed by yt-dlp releases).
+run:
+    pip install -U yt-dlp
+    python main.py
+
 # Lint: blocking errors only (same as CI)
 lint:
     ruff check --select E9,F63,F7,F82 .

--- a/justfile
+++ b/justfile
@@ -53,6 +53,11 @@ review pr:
         tmux attach-session -t "$session"
     fi
 
+
+review_watcher:
+  #!/usr/bin/env bash
+  tmux new-session -d -s review-queue 'just queue-watch'
+
 # Watch /tmp/tele-bot-review-queue/pending/ for review requests from the bot.
 # The bot's /review handler writes JSON files there with caller info + PR number.
 # This watcher picks each up and spawns `claude --print '/review-pr-ukr N'` in tmux.
@@ -129,11 +134,11 @@ queue-watch:
              echo 'claude --version:'; claude --version 2>/dev/null || true; \
              echo 'PWD:' \$(pwd); \
              echo; \
-             echo '──── claude output (verbose) ────'; \
-             ( while sleep 20; do echo \"[\$(date +'%F %T')] ⏳ still working...\"; done ) & HB=\$!; \
-             claude --verbose --print '/review-pr-ukr $pr' 2>&1 | awk '{ print strftime(\"[%F %T]\"), \$0; fflush() }'; \
+             echo '──── claude output ────'; \
+             claude --output-format stream-json '/review-pr-ukr $pr' 2>&1 \
+               | jq -r --unbuffered 'if .type == \"assistant\" then (.message.content[] | select(.type == \"text\") | .text) elif .type == \"result\" then \"\\n✅ Done (exit=\\(.subtype))\" else empty end' 2>/dev/null \
+               | awk '{ print strftime(\"[%F %T]\"), \$0; fflush() }'; \
              rc=\${PIPESTATUS[0]}; \
-             kill \$HB 2>/dev/null; wait \$HB 2>/dev/null; \
              echo; echo \"──── claude exit=\$rc ────\"; \
              jq --arg ts \"\$(date -u +%FT%TZ)\" --argjson rc \$rc --arg log '$log' \
                 '. + {completed_at: \$ts, exit_code: \$rc, status: (if \$rc == 0 then \"success\" else \"failed\" end), log_file: \$log}' \

--- a/main.py
+++ b/main.py
@@ -155,7 +155,14 @@ async def handle_inst_tick(message: types.Message, cfg):
     loc_video = f"media/{user.id}/%(title)s.%(ext)s"
 
     ydl_opts = {
-        "format": "bestvideo+bestaudio/best",
+        # Prefer H.264 (avc1) + AAC so the file plays on Apple devices (iOS/macOS/Safari).
+        # Falls back to any mp4 streams, then any format yt-dlp can find.
+        "format": (
+            "bestvideo[vcodec^=avc1]+bestaudio[ext=m4a]"
+            "/bestvideo[ext=mp4]+bestaudio[ext=m4a]"
+            "/bestvideo+bestaudio/best"
+        ),
+        "merge_output_format": "mp4",
         "outtmpl": loc_video,
     }
 

--- a/main.py
+++ b/main.py
@@ -73,7 +73,7 @@ async def start_user(message:types.Message):
 
 
 @dp.message(lambda msg: msg.text and any(link in msg.text for link in ['youtu.be', 'youtube.com']))
-async def cmd_numbers(message: types.Message):
+async def cmd_numbers(message: types.Message, cfg):
     user_bot = message.from_user
     link = ut.expand_url(message.text)
     link = link.split('&list')[0]
@@ -86,12 +86,59 @@ async def cmd_numbers(message: types.Message):
     user = ut.pandas2pydentic(df_t)
     available_memory = user.level.value - user.use_memory
     logger.info(f'User {user.id} {ut.get_name_from_pydantic(user)} has {ut.h_readable(available_memory)=}')
-    
+
     if available_memory < 0:
         await message.reply(f"Ви використали свій ліміт({ut.h_readable(user.level.value)})"+
                              f" на цей місяць, підніміть свій статус")
         return
-    
+
+    # If the message came via inline bot, auto-download best quality
+    if message.via_bot:
+        logger.info(f'Inline YouTube download for {user.id}: {link}')
+        environment = jinja2.Environment()
+        answer_template = environment.from_string(
+            "@{{bot_name}}\n\nУ тебе лишилося {{avail_mem}}\n\n{{progress_bar_str_value}}\n\n{{url}}"
+        )
+
+        current_date = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        loc_video = f"media/{user.id}/{current_date}"
+        ydl_opts = {
+            'format': 'bestvideo+bestaudio/best',
+            'outtmpl': loc_video,
+        }
+
+        res = await bot_func.get_dwn_media(ydl_opts, message, youtubeLink=link)
+        if not res:
+            await message.answer('Не вдалося завантажити. Перевір посилання і спробуй ще раз.')
+            logger.warning(f'Failed to download inline YouTube video {link}\n\n\n')
+            return
+        loc_video, file_size = res
+
+        available_memory -= file_size
+        total_mem_user_level = user.level.value
+        used_memory_per_user = user.use_memory
+
+        answer_cap = answer_template.render(
+            bot_name=cfg.shared_vars.bot_name,
+            avail_mem=ut.h_readable(available_memory),
+            progress_bar_str_value=ut.progress_bar_str(used_memory_per_user, total_mem_user_level),
+            url=link,
+        )
+
+        try:
+            await message.answer_video(
+                video=types.FSInputFile(loc_video), caption=answer_cap
+            )
+        except Exception as e:
+            await message.reply(f"An error occurred while sending the video: {e}")
+        user.use_memory += file_size
+        loc_match = glob.glob(os.path.join('.', f'{loc_video}*'))
+        assert loc_match
+        loc_video = loc_match[0]
+        ut.update_row(user)
+        ut.delete_video_file(loc_video)
+        return
+
     wait_bot_msg = await message.reply(f"Твоя лінка на youtube повідомлення опрацьовується!\
                                         У тебе лишилося {ut.h_readable(available_memory)}", disable_notification=True)
     logger.success(f'Хапнули лінку {link} --> {user.id} {ut.get_name_from_pydantic(user)}')
@@ -102,12 +149,12 @@ async def cmd_numbers(message: types.Message):
         logger.warning(f'Failed to download media formats with link {message.text}\n\n\n')
         return
 
-        
+
     yt_info, all_butons = res
     video_name = yt_info['title']
     id_video = yt_info['id']
     await message.reply(
-                        f"Яке хочете розширення? \n {link}\n повідомлення {user.full_name} \n\n" + 
+                        f"Яке хочете розширення? \n {link}\n повідомлення {user.full_name} \n\n" +
                         f"Vidoe --> {video_name}\nId --> {id_video} \n" +
                         f"У тебе лишилося {ut.h_readable(available_memory)}",
                         reply_markup=all_butons)

--- a/main.py
+++ b/main.py
@@ -168,7 +168,7 @@ async def handle_inst_tick(message: types.Message, cfg):
         "outtmpl": loc_video,
     }
 
-    res = await bot_func.get_dwn_media(ydl_opts, message)
+    res = await bot_func.get_dwn_media(ydl_opts, message, user_id=user.id)
     if not res:
         await message.answer(
             "Не вдалося завантажити. Перевір посилання і спробуй ще раз."

--- a/main.py
+++ b/main.py
@@ -155,13 +155,15 @@ async def handle_inst_tick(message: types.Message, cfg):
     loc_video = f"media/{user.id}/%(title)s.%(ext)s"
 
     ydl_opts = {
-        # Prefer H.264 (avc1) + AAC so the file plays on Apple devices (iOS/macOS/Safari).
-        # Falls back to any mp4 streams, then any format yt-dlp can find.
+        # Prefer H.264 + AAC. format_sort ranks h264 highest so the
+        # bestvideo fallback also picks H.264 when available.
+        # _ensure_h264() transcodes as a last resort if only VP9/AV1 exist.
         "format": (
             "bestvideo[vcodec^=avc1]+bestaudio[ext=m4a]"
             "/bestvideo[ext=mp4]+bestaudio[ext=m4a]"
             "/bestvideo+bestaudio/best"
         ),
+        "format_sort": ["vcodec:h264"],
         "merge_output_format": "mp4",
         "outtmpl": loc_video,
     }

--- a/main.py
+++ b/main.py
@@ -154,7 +154,7 @@ async def handle_inst_tick(message: types.Message, cfg):
         return
 
     current_date = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    loc_video = f"media/{user.id}/{current_date}.%(ext)s"
+    loc_video = f"media/{user.id}/%(title)s.%(ext)s"
 
     ydl_opts = {
         "format": "bestvideo+bestaudio/best",

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import os
 from pathlib import Path
 
@@ -153,7 +152,6 @@ async def handle_inst_tick(message: types.Message, cfg):
         )
         return
 
-    current_date = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     loc_video = f"media/{user.id}/%(title)s.%(ext)s"
 
     ydl_opts = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ python-dotenv==1.0.1
 pyyaml==6.0.2
 tomli==2.0.1
 tqdm==4.67.1
-yt-dlp==2025.3.27
+yt-dlp>=2026.3.17
 curl_cffi==0.10.0
 easydict==1.13
 srtools==0.1.13

--- a/src/bot.py
+++ b/src/bot.py
@@ -4,10 +4,14 @@ import contextlib
 import glob
 import json
 import re
-from enum import Enum
 from datetime import datetime
 from pathlib import Path
 import yt_dlp
+from src.download_errors import (
+    classify_download_error,
+    is_retriable_error,
+    ERROR_USER_MESSAGES,
+)
 import os
 import asyncio
 import time
@@ -22,138 +26,6 @@ LIMIT_SIZE_UPL_VIDEO = 49
 # succeeds on the next attempt). Backoff grows: RETRY_BASE_DELAY * attempt.
 MAX_DOWNLOAD_ATTEMPTS = 4
 RETRY_BASE_DELAY = 1.5
-
-class DownloadErrorKind(Enum):
-    """Category of a yt-dlp download failure, inferred from its error text.
-
-    Drives three things: whether we retry (transient kinds only), what message
-    the user sees, and how the failure is tagged in logs/download_issues.jsonl.
-    """
-
-    AGE_RESTRICTED = "age_restricted"  # site wants sign-in to confirm age
-    LOGIN_REQUIRED = "login_required"  # private / sign-in / bot-check
-    UNAVAILABLE = "unavailable"  # removed / deleted / private / not found
-    GEO_BLOCKED = "geo_blocked"  # not available in this country
-    RATE_LIMITED = "rate_limited"  # HTTP 429 / too many requests
-    UNSUPPORTED = "unsupported"  # unsupported URL / no extractor / no formats
-    NETWORK = "network"  # timeout / connection / 5xx (transient)
-    EXTRACTION = "extraction"  # rehydration / "unable to extract" (flaky)
-    UNKNOWN = "unknown"  # anything we could not classify
-
-
-# Ordered most-specific → most-generic: the first kind with a matching
-# substring wins, so AGE/LOGIN/UNAVAILABLE are checked before the broad
-# EXTRACTION markers. Match is a case-insensitive substring of the message.
-_ERROR_KIND_MARKERS: dict[DownloadErrorKind, tuple[str, ...]] = {
-    DownloadErrorKind.AGE_RESTRICTED: (
-        "confirm your age",
-        "age-restricted",
-        "age restricted",
-        "inappropriate for some users",
-    ),
-    DownloadErrorKind.LOGIN_REQUIRED: (
-        "sign in to confirm you're not a bot",
-        "sign in",
-        "log in to",
-        "login required",
-        "requires authentication",
-        "private video",
-        "this video is private",
-        "this account is private",
-        "use --cookies",
-    ),
-    DownloadErrorKind.GEO_BLOCKED: (
-        "not available in your country",
-        "in your country",
-        "geo restricted",
-        "geo-restricted",
-    ),
-    DownloadErrorKind.RATE_LIMITED: (
-        "http error 429",
-        "too many requests",
-        "rate-limit",
-        "rate limit",
-    ),
-    DownloadErrorKind.UNAVAILABLE: (
-        "video unavailable",
-        "no longer available",
-        "has been removed",
-        "was deleted",
-        "this post may not be available",
-        "http error 404",
-        "account has been terminated",
-    ),
-    DownloadErrorKind.UNSUPPORTED: (
-        "unsupported url",
-        "no suitable extractor",
-        "no video formats found",
-        "is not a valid url",
-    ),
-    DownloadErrorKind.NETWORK: (
-        "timed out",
-        "timeout",
-        "read timed out",
-        "connection",
-        "temporarily",
-        "http error 5",
-        "remote end closed",
-    ),
-    DownloadErrorKind.EXTRACTION: (
-        "rehydration",
-        "universal data",
-        "unable to extract",
-        "unable to download webpage",
-        "challenge",
-    ),
-}
-
-# Kinds where retrying has a real chance of succeeding.
-_RETRIABLE_KINDS = frozenset(
-    {
-        DownloadErrorKind.NETWORK,
-        DownloadErrorKind.EXTRACTION,
-        DownloadErrorKind.RATE_LIMITED,
-    }
-)
-
-# User-facing (Ukrainian) message per kind. UNKNOWN falls back to the raw error.
-_ERROR_USER_MESSAGES = {
-    DownloadErrorKind.AGE_RESTRICTED: (
-        "🔞 Відео з віковим обмеженням — сайт вимагає вхід/підтвердження віку, "
-        "тож завантажити не вдалося."
-    ),
-    DownloadErrorKind.LOGIN_REQUIRED: (
-        "🔒 Відео приватне або потребує входу — завантажити не можу."
-    ),
-    DownloadErrorKind.UNAVAILABLE: (
-        "🚫 Відео недоступне (видалене, приватне або не існує)."
-    ),
-    DownloadErrorKind.GEO_BLOCKED: "🌍 Відео недоступне у цьому регіоні.",
-    DownloadErrorKind.RATE_LIMITED: (
-        "⏳ Забагато запитів до сайту. Спробуй, будь ласка, трохи згодом."
-    ),
-    DownloadErrorKind.UNSUPPORTED: "❓ Це посилання не підтримується.",
-    DownloadErrorKind.NETWORK: (
-        "📡 Проблема з мережею під час завантаження. Спробуй ще раз."
-    ),
-    DownloadErrorKind.EXTRACTION: (
-        "⚠️ Сайт тимчасово не віддає відео. Спробуй ще раз за хвилину."
-    ),
-}
-
-
-def classify_download_error(msg: str) -> DownloadErrorKind:
-    """Map a yt-dlp error message to a DownloadErrorKind (first match wins)."""
-    low = msg.lower()
-    for kind, markers in _ERROR_KIND_MARKERS.items():
-        if any(marker in low for marker in markers):
-            return kind
-    return DownloadErrorKind.UNKNOWN
-
-
-def _is_retriable_error(msg: str) -> bool:
-    """True if the error is a transient kind worth retrying."""
-    return classify_download_error(msg) in _RETRIABLE_KINDS
 
 
 # Network/extractor robustness defaults shared by every yt-dlp call.
@@ -483,7 +355,7 @@ class Bot_Func:
                         with yt_dlp.YoutubeDL(opts) as ydl:
                             return ydl.extract_info(med_url, download=True)
                     except yt_dlp.utils.DownloadError as e:
-                        if attempt >= MAX_DOWNLOAD_ATTEMPTS or not _is_retriable_error(
+                        if attempt >= MAX_DOWNLOAD_ATTEMPTS or not is_retriable_error(
                             str(e)
                         ):
                             raise
@@ -558,7 +430,7 @@ class Bot_Func:
             )
             if strt_dwn_msg:
                 await strt_dwn_msg.delete()
-            await user_msg.reply(_ERROR_USER_MESSAGES.get(kind, f"Download error: {e}"))
+            await user_msg.reply(ERROR_USER_MESSAGES.get(kind, f"Download error: {e}"))
             return
         except Exception as e:
             self.log.error(f"❌ An error occurred: {e}")

--- a/src/bot.py
+++ b/src/bot.py
@@ -43,6 +43,32 @@ class Bot_Func:
         self.log = log
         self.root_prj = root_prj
 
+    def _log_media_info(self, info: dict | None) -> str:
+        """Log codec/resolution/bitrate and return the same text for sidecar writing."""
+        if not info:
+            return ""
+        # For merged/remuxed formats the final stream data lives under
+        # requested_downloads[0]; fall back to top-level info_dict fields.
+        rd = (info.get("requested_downloads") or [{}])[0]
+        src = rd if rd else info
+
+        vcodec = src.get("vcodec") or info.get("vcodec", "?")
+        acodec = src.get("acodec") or info.get("acodec", "?")
+        width = src.get("width") or info.get("width")
+        height = src.get("height") or info.get("height")
+        fps = src.get("fps") or info.get("fps")
+        tbr = src.get("tbr") or info.get("tbr")  # total bitrate kbps
+        ext = src.get("ext") or info.get("ext", "?")
+        title = info.get("title", "")
+        url = info.get("webpage_url") or info.get("original_url", "")
+
+        res = f"{width}x{height}" if width and height else "?x?"
+        fps_str = f" @ {fps:.0f}fps" if fps else ""
+        tbr_str = f" | {tbr:.0f}kbps" if tbr else ""
+        line = f"🎬 {title!r} | {ext} | {vcodec} / {acodec} | {res}{fps_str}{tbr_str}"
+        self.log.info(line)
+        return "\n".join([line, f"url: {url}", f"title: {title}"])
+
     def extract_video_info(self, url):
         """Extract video metadata (title, thumbnail, duration). Blocking."""
         try:
@@ -76,6 +102,7 @@ class Bot_Func:
 
         strt_dwn_msg = None
         finished_file: str = ""
+        media_info: dict | None = None
         try:
             strt_dwn_msg = await user_msg.answer("Downloading... 0%\n⬜⬜⬜⬜⬜⬜⬜⬜")
             self.log.debug(f"Start download video {loc_video}")
@@ -133,11 +160,12 @@ class Bot_Func:
 
             def download():
                 with yt_dlp.YoutubeDL(ydl_opts_with_hook) as ydl:
-                    ydl.download([med_url])
+                    return ydl.extract_info(med_url, download=True)
 
-            await asyncio.to_thread(download)
+            media_info = await asyncio.to_thread(download)
             await strt_dwn_msg.delete()
             self.log.success(f"✅ Download successful! {loc_video}")
+            self._log_media_info(media_info)
         except yt_dlp.utils.DownloadError as e:
             self.log.error(f"❌ Download error: {e}")
             if strt_dwn_msg:
@@ -182,9 +210,13 @@ class Bot_Func:
         date_str = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         stem, _ = ut.parse_media_filename(loc_video)
         sidecar = f"{os.path.dirname(loc_video)}/{stem}__{date_str}.txt"
-        Path(sidecar).touch()
+        file_size = os.path.getsize(loc_video)
+        sidecar_text = self._log_media_info(media_info)
+        Path(sidecar).write_text(
+            sidecar_text + f"\nsize: {ut.h_readable(file_size)}\n", encoding="utf-8"
+        )
 
-        self.log.info(f"File size: {ut.h_readable(os.path.getsize(loc_video))}")
+        self.log.info(f"File size: {ut.h_readable(file_size)}")
 
         # TODO: show awailable limit for user
         # await message.answer(f'Твоє відео {tiktok_url}')

--- a/src/bot.py
+++ b/src/bot.py
@@ -14,6 +14,35 @@ from aiogram import types
 
 LIMIT_SIZE_UPL_VIDEO = 49
 
+# How many times to retry a download when a *transient* error happens
+# (e.g. TikTok "rehydration" extraction flakiness — the same link often
+# succeeds on the next attempt). Backoff grows: RETRY_BASE_DELAY * attempt.
+MAX_DOWNLOAD_ATTEMPTS = 4
+RETRY_BASE_DELAY = 1.5
+
+# Substrings that mark a *temporary* failure worth retrying. Anything else
+# (private/removed video, unsupported URL, ...) fails immediately.
+_RETRIABLE_MARKERS = (
+    "rehydration",
+    "universal data",
+    "unable to extract",
+    "unable to download webpage",
+    "challenge",
+    "timed out",
+    "timeout",
+    "connection",
+    "temporarily",
+    "http error 5",
+    "read timed out",
+)
+
+
+def _is_retriable_error(msg: str) -> bool:
+    """True if the yt-dlp error message looks like a transient, retriable one."""
+    low = msg.lower()
+    return any(marker in low for marker in _RETRIABLE_MARKERS)
+
+
 vid_format_dict = {
     "audio only": "🎧",
     "256x144": "144p",
@@ -210,14 +239,56 @@ class Bot_Func:
                     pass
 
             ydl_opts_with_hook = {
+                # Network/extractor robustness defaults — caller's ydl_opts may
+                # override any of these via the spread below.
+                "retries": 5,
+                "fragment_retries": 5,
+                "extractor_retries": 3,
+                "socket_timeout": 30,
                 **ydl_opts,
                 "progress_hooks": [progress_hook],
                 "postprocessor_hooks": [pp_hook],
             }
 
             def download():
-                with yt_dlp.YoutubeDL(ydl_opts_with_hook) as ydl:
-                    return ydl.extract_info(med_url, download=True)
+                # Retry transient failures (TikTok rehydration flakiness, timeouts,
+                # transient network errors). The same link that fails once usually
+                # succeeds on the next attempt — see logs in the bug report.
+                base = re.sub(r"\.?%\([^)]+\)s", "", loc_video)
+                last_err = None
+                for attempt in range(1, MAX_DOWNLOAD_ATTEMPTS + 1):
+                    try:
+                        with yt_dlp.YoutubeDL(ydl_opts_with_hook) as ydl:
+                            return ydl.extract_info(med_url, download=True)
+                    except yt_dlp.utils.DownloadError as e:
+                        last_err = e
+                        if attempt >= MAX_DOWNLOAD_ATTEMPTS or not _is_retriable_error(
+                            str(e)
+                        ):
+                            raise
+                        self.log.warning(
+                            f"⚠️ Download attempt {attempt}/{MAX_DOWNLOAD_ATTEMPTS} "
+                            f"failed (retriable), retrying: {e}"
+                        )
+                        # Let the user know we're retrying (best-effort).
+                        asyncio.run_coroutine_threadsafe(
+                            _edit_progress(
+                                f"⚠️ Спроба {attempt} не вдалась, пробую ще раз…"
+                            ),
+                            loop,
+                        )
+                        # Drop half-downloaded leftovers before the next attempt.
+                        if base:
+                            for leftover in glob.glob(glob.escape(base) + "*"):
+                                if leftover.endswith((".part", ".ytdl")):
+                                    try:
+                                        os.remove(leftover)
+                                    except OSError:
+                                        pass
+                        time.sleep(RETRY_BASE_DELAY * attempt)
+                # Exhausted retries — re-raise for the outer DownloadError handler.
+                if last_err:
+                    raise last_err
 
             media_info = await asyncio.to_thread(download)
             await strt_dwn_msg.delete()

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,6 +1,8 @@
 # import utils as ut
 from src import utils as ut
 import glob
+import re
+from datetime import datetime
 import yt_dlp
 import os
 import asyncio
@@ -12,16 +14,16 @@ from aiogram import types
 LIMIT_SIZE_UPL_VIDEO = 49
 
 vid_format_dict = {
-    'audio only': '🎧',
-    '256x144': '144p',
-    '426x240': '240p',
-    '640x360': '360p',
-    '854x480': '480p',
-    '1280x720': 'HD',
-    '1920x1080': 'Full HD',
-    '2560x1440': '2K',
-    '3840x2160': '4K',
-    '7680x4320': '8K',
+    "audio only": "🎧",
+    "256x144": "144p",
+    "426x240": "240p",
+    "640x360": "360p",
+    "854x480": "480p",
+    "1280x720": "HD",
+    "1920x1080": "Full HD",
+    "2560x1440": "2K",
+    "3840x2160": "4K",
+    "7680x4320": "8K",
 }
 
 
@@ -35,11 +37,7 @@ class CommonParamInline(CallbackData, prefix="idl"):
     key: str
 
 
-
-
-
 class Bot_Func:
-
     def __init__(self, log, root_prj):
         self.log = log
         self.root_prj = root_prj
@@ -47,12 +45,12 @@ class Bot_Func:
     def extract_video_info(self, url):
         """Extract video metadata (title, thumbnail, duration). Blocking."""
         try:
-            with yt_dlp.YoutubeDL({'quiet': True, 'skip_download': True}) as ydl:
+            with yt_dlp.YoutubeDL({"quiet": True, "skip_download": True}) as ydl:
                 info = ydl.extract_info(url, download=False)
                 return {
-                    'thumbnail': info.get('thumbnail', ''),
-                    'title': info.get('title', 'Video'),
-                    'duration': info.get('duration', 0),
+                    "thumbnail": info.get("thumbnail", ""),
+                    "title": info.get("title", "Video"),
+                    "duration": info.get("duration", 0),
                 }
         except Exception as e:
             self.log.error(f"Video info extraction error: {e}")
@@ -61,24 +59,25 @@ class Bot_Func:
     def search_youtube(self, query, max_results=3):
         """Search YouTube via ytsearch. Blocking."""
         try:
-            with yt_dlp.YoutubeDL({'quiet': True, 'extract_flat': True}) as ydl:
-                result = ydl.extract_info(f"ytsearch{max_results}:{query}", download=False)
-                return result.get('entries', [])
+            with yt_dlp.YoutubeDL({"quiet": True, "extract_flat": True}) as ydl:
+                result = ydl.extract_info(
+                    f"ytsearch{max_results}:{query}", download=False
+                )
+                return result.get("entries", [])
         except Exception as e:
             self.log.error(f"YouTube search error: {e}")
             return []
 
-
-
-    async def get_dwn_media(self, ydl_opts, user_msg, youtubeLink=''):
+    async def get_dwn_media(self, ydl_opts, user_msg, youtubeLink=""):
         med_url = youtubeLink if youtubeLink else user_msg.text
 
-        loc_video = ydl_opts['outtmpl']
+        loc_video = ydl_opts["outtmpl"]
 
         strt_dwn_msg = None
+        finished_files: list[str] = []
         try:
             strt_dwn_msg = await user_msg.answer("Downloading... 0%\n⬜⬜⬜⬜⬜⬜⬜⬜")
-            self.log.debug(f'Start download video {loc_video}')
+            self.log.debug(f"Start download video {loc_video}")
 
             loop = asyncio.get_running_loop()
             last_update = [0.0]
@@ -90,33 +89,36 @@ class Bot_Func:
                     pass
 
             def progress_hook(d):
-                if d['status'] != 'downloading':
+                if d["status"] == "finished":
+                    filename = d.get("filename", "")
+                    if filename:
+                        finished_files.append(filename)
+                    return
+                if d["status"] != "downloading":
                     return
                 now = time.time()
                 if now - last_update[0] < 2:
                     return
                 last_update[0] = now
 
-                total = d.get('total_bytes') or d.get('total_bytes_estimate', 0)
-                downloaded = d.get('downloaded_bytes', 0)
+                total = d.get("total_bytes") or d.get("total_bytes_estimate", 0)
+                downloaded = d.get("downloaded_bytes", 0)
                 if total <= 0:
                     return
 
                 pct = downloaded / total * 100
                 filled = int(8 * downloaded // total)
-                bar = '🟩' * filled + '⬜' * (8 - filled)
-                speed = d.get('speed', 0)
+                bar = "🟩" * filled + "⬜" * (8 - filled)
+                speed = d.get("speed", 0)
                 speed_str = f" | {speed / 1024 / 1024:.1f} MB/s" if speed else ""
                 text = f"Downloading... {pct:.0f}%\n{bar}{speed_str}"
 
                 try:
-                    asyncio.run_coroutine_threadsafe(
-                        _edit_progress(text), loop
-                    )
+                    asyncio.run_coroutine_threadsafe(_edit_progress(text), loop)
                 except Exception:
                     pass
 
-            ydl_opts_with_hook = {**ydl_opts, 'progress_hooks': [progress_hook]}
+            ydl_opts_with_hook = {**ydl_opts, "progress_hooks": [progress_hook]}
 
             def download():
                 with yt_dlp.YoutubeDL(ydl_opts_with_hook) as ydl:
@@ -138,51 +140,61 @@ class Bot_Func:
             await user_msg.reply(f"An error occurred: {e}")
             return
 
-        pattern = glob.escape(loc_video.replace('.%(ext)s', '')) + '.*'
-        loc_match = glob.glob(os.path.join('.', pattern))
+        # Resolve actual file path: prefer hook-captured name, fall back to glob
+        if finished_files and os.path.exists(finished_files[-1]):
+            loc_video = finished_files[-1]
+        else:
+            base_path = re.sub(r"\.?%\([^)]+\)s", "", loc_video)
+            if not base_path or base_path.endswith("/"):
+                await user_msg.reply(
+                    f"Download finished but file not found. {loc_video=}"
+                )
+                return
+            pattern = glob.escape(base_path) + "*"
+            loc_match = glob.glob(os.path.join(".", pattern))
+            if not loc_match:
+                await user_msg.reply(
+                    f"Download finished but file not found. {loc_video=}"
+                )
+                return
+            loc_video = loc_match[0]
 
-        if not loc_match:
-            await user_msg.reply(f"Download finished but file not found. {loc_video=}")
-            return
-
-        loc_video  = loc_match[0]
-        # await info_wait_button.delete()
         # Check if the file exists
         if not os.path.exists(loc_video):
             await user_msg.reply(f"The video file does not exist. {loc_video=}")
-            return 
+            return
 
-        
+        # Write sidecar .txt with download date
+        sidecar = os.path.splitext(loc_video)[0] + ".txt"
+        with open(sidecar, "w") as f:
+            f.write(datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+
         self.log.info(f"File size: {ut.h_readable(os.path.getsize(loc_video))}")
 
-        
-
-        #TODO: show awailable limit for user
+        # TODO: show awailable limit for user
         # await message.answer(f'Твоє відео {tiktok_url}')
 
         return (loc_video, os.path.getsize(loc_video))
-    
-
 
     def _list_formats(self, video_url):
         # video_url = ut.expand_url(video_url)
 
         # Options for yt-dlp
         # TODO: format not worl
-        min_format=420
-        max_format=1080
+        min_format = 420
+        max_format = 1080
         ydl_opts = {
-            'quiet': True,
-            'format':   f'bestvideo[height<={max_format}][height>={min_format}]' + 
-                        f'+bestaudio/best[height<={max_format}][height>={min_format}]',
+            "quiet": True,
+            "format": f"bestvideo[height<={max_format}][height>={min_format}]"
+            + f"+bestaudio/best[height<={max_format}][height>={min_format}]",
         }
 
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             try:
-                self.log.info('Скачується формати відео  .....')
+                self.log.info("Скачується формати відео  .....")
                 info_dict = ydl.extract_info(video_url, download=False)
-                video_name = info_dict['title']
-                self.log.info(f'Скачали формати відео з назвою {video_name}')
+                video_name = info_dict["title"]
+                self.log.info(f"Скачали формати відео з назвою {video_name}")
                 # pprint(json.dumps(ydl.sanitize_info(info_dict)))
 
                 # formats = info_dict.get('formats', [])
@@ -195,72 +207,76 @@ class Bot_Func:
                 self.log.debug(f"An unexpected error occurred: {e}")
                 raise e
 
-
-    #TODO: log that start collect formats
+    # TODO: log that start collect formats
     def get_keyboard(self, link):
         try:
             yt_info = self._list_formats(link)
         except Exception:
-            self.log.error('Failed to download youtube format')
+            self.log.error("Failed to download youtube format")
             return
 
         # yt_info['id']
         # yt_info['title']
-        formats = yt_info.get('formats', [])
+        formats = yt_info.get("formats", [])
 
         buttons = []
         all_audio_size = [0]
-        self.log.info(f'Create buttond for video {yt_info['title']}')
+        self.log.info(f"Create buttond for video {yt_info['title']}")
         for fmt in formats:
-            format_id = fmt.get('format_id')
-            filesize = fmt.get('filesize')
+            format_id = fmt.get("format_id")
+            filesize = fmt.get("filesize")
 
             data = {}
             # data['id'] = yt_info['id']
-            
-            data['vid_data'] = f"vid_{format_id}"
 
-            data['title'] = yt_info['title'].replace(':', '_')
+            data["vid_data"] = f"vid_{format_id}"
 
-            if not ut.is_ltn(data['title']):
-                data['title'] = ut.cr_2_ln(data['title'])
-            
-            data['title'] = ut.remove_non_ascii(data['title'])
+            data["title"] = yt_info["title"].replace(":", "_")
 
-            len_txt = 64 - 2 - len('vid') - len(data['vid_data'])
-            data['title'] = data['title'][:len_txt]
+            if not ut.is_ltn(data["title"]):
+                data["title"] = ut.cr_2_ln(data["title"])
 
-            
+            data["title"] = ut.remove_non_ascii(data["title"])
 
-            resolution = fmt.get('resolution')
+            len_txt = 64 - 2 - len("vid") - len(data["vid_data"])
+            data["title"] = data["title"][:len_txt]
+
+            resolution = fmt.get("resolution")
             resolution = vid_format_dict.get(resolution, resolution)
 
             IsVideo = False
-            ext = fmt['ext']
+            ext = fmt["ext"]
 
-
-            if ext == 'webm' or not filesize:
+            if ext == "webm" or not filesize:
                 continue
 
-            if ext == 'm4a':
+            if ext == "m4a":
                 all_audio_size.append(filesize)
-                ext = ''
+                ext = ""
 
-            if ext == 'mp4':
+            if ext == "mp4":
                 IsVideo = True
-            cb1 = CommonParamYouTube(title = data['title'] , vid_data=data['vid_data'])
-            self.log.trace(f'Create buuton {cb1}')
+            cb1 = CommonParamYouTube(title=data["title"], vid_data=data["vid_data"])
+            self.log.trace(f"Create buuton {cb1}")
 
             real_size = (filesize, filesize + max(all_audio_size))[IsVideo]
 
-            if (filesize and real_size < LIMIT_SIZE_UPL_VIDEO * 1024 * 1024):
+            if filesize and real_size < LIMIT_SIZE_UPL_VIDEO * 1024 * 1024:
                 buttons.append(
-                    types.InlineKeyboardButton(text=f"{resolution} {ext} {ut.h_readable(real_size)}",
-                                                           callback_data=cb1.pack()))
+                    types.InlineKeyboardButton(
+                        text=f"{resolution} {ext} {ut.h_readable(real_size)}",
+                        callback_data=cb1.pack(),
+                    )
+                )
 
         if not buttons:
-            buttons.append(types.InlineKeyboardButton(text="No formats with filesize available", callback_data="no_formats"))
+            buttons.append(
+                types.InlineKeyboardButton(
+                    text="No formats with filesize available",
+                    callback_data="no_formats",
+                )
+            )
 
-        paired_buttons = ([buttons[i:i+2] for i in range(0, len(buttons), 2)])
+        paired_buttons = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
         keyboard = types.InlineKeyboardMarkup(inline_keyboard=paired_buttons)
         return (yt_info, keyboard)

--- a/src/bot.py
+++ b/src/bot.py
@@ -4,6 +4,7 @@ import contextlib
 import glob
 import json
 import re
+from enum import Enum
 from datetime import datetime
 from pathlib import Path
 import yt_dlp
@@ -22,27 +23,162 @@ LIMIT_SIZE_UPL_VIDEO = 49
 MAX_DOWNLOAD_ATTEMPTS = 4
 RETRY_BASE_DELAY = 1.5
 
-# Substrings that mark a *temporary* failure worth retrying. Anything else
-# (private/removed video, unsupported URL, ...) fails immediately.
-_RETRIABLE_MARKERS = (
-    "rehydration",
-    "universal data",
-    "unable to extract",
-    "unable to download webpage",
-    "challenge",
-    "timed out",
-    "timeout",
-    "connection",
-    "temporarily",
-    "http error 5",
-    "read timed out",
+class DownloadErrorKind(Enum):
+    """Category of a yt-dlp download failure, inferred from its error text.
+
+    Drives three things: whether we retry (transient kinds only), what message
+    the user sees, and how the failure is tagged in logs/download_issues.jsonl.
+    """
+
+    AGE_RESTRICTED = "age_restricted"  # site wants sign-in to confirm age
+    LOGIN_REQUIRED = "login_required"  # private / sign-in / bot-check
+    UNAVAILABLE = "unavailable"  # removed / deleted / private / not found
+    GEO_BLOCKED = "geo_blocked"  # not available in this country
+    RATE_LIMITED = "rate_limited"  # HTTP 429 / too many requests
+    UNSUPPORTED = "unsupported"  # unsupported URL / no extractor / no formats
+    NETWORK = "network"  # timeout / connection / 5xx (transient)
+    EXTRACTION = "extraction"  # rehydration / "unable to extract" (flaky)
+    UNKNOWN = "unknown"  # anything we could not classify
+
+
+# Ordered most-specific → most-generic: the first kind with a matching
+# substring wins, so AGE/LOGIN/UNAVAILABLE are checked before the broad
+# EXTRACTION markers. Match is a case-insensitive substring of the message.
+_ERROR_KIND_MARKERS: tuple[tuple[DownloadErrorKind, tuple[str, ...]], ...] = (
+    (
+        DownloadErrorKind.AGE_RESTRICTED,
+        (
+            "confirm your age",
+            "age-restricted",
+            "age restricted",
+            "inappropriate for some users",
+        ),
+    ),
+    (
+        DownloadErrorKind.LOGIN_REQUIRED,
+        (
+            "sign in to confirm you're not a bot",
+            "sign in",
+            "log in to",
+            "login required",
+            "requires authentication",
+            "private video",
+            "this video is private",
+            "this account is private",
+            "use --cookies",
+        ),
+    ),
+    (
+        DownloadErrorKind.GEO_BLOCKED,
+        (
+            "not available in your country",
+            "in your country",
+            "geo restricted",
+            "geo-restricted",
+        ),
+    ),
+    (
+        DownloadErrorKind.RATE_LIMITED,
+        ("http error 429", "too many requests", "rate-limit", "rate limit"),
+    ),
+    (
+        DownloadErrorKind.UNAVAILABLE,
+        (
+            "video unavailable",
+            "no longer available",
+            "has been removed",
+            "was deleted",
+            "this post may not be available",
+            "http error 404",
+            "account has been terminated",
+        ),
+    ),
+    (
+        DownloadErrorKind.UNSUPPORTED,
+        (
+            "unsupported url",
+            "no suitable extractor",
+            "no video formats found",
+            "is not a valid url",
+        ),
+    ),
+    (
+        DownloadErrorKind.NETWORK,
+        (
+            "timed out",
+            "timeout",
+            "read timed out",
+            "connection",
+            "temporarily",
+            "http error 5",
+            "remote end closed",
+        ),
+    ),
+    (
+        DownloadErrorKind.EXTRACTION,
+        (
+            "rehydration",
+            "universal data",
+            "unable to extract",
+            "unable to download webpage",
+            "challenge",
+        ),
+    ),
 )
+
+# Kinds where retrying has a real chance of succeeding.
+_RETRIABLE_KINDS = frozenset(
+    {
+        DownloadErrorKind.NETWORK,
+        DownloadErrorKind.EXTRACTION,
+        DownloadErrorKind.RATE_LIMITED,
+    }
+)
+
+# User-facing (Ukrainian) message per kind. UNKNOWN falls back to the raw error.
+_ERROR_USER_MESSAGES = {
+    DownloadErrorKind.AGE_RESTRICTED: (
+        "🔞 Відео з віковим обмеженням — сайт вимагає вхід/підтвердження віку, "
+        "тож завантажити не вдалося."
+    ),
+    DownloadErrorKind.LOGIN_REQUIRED: (
+        "🔒 Відео приватне або потребує входу — завантажити не можу."
+    ),
+    DownloadErrorKind.UNAVAILABLE: (
+        "🚫 Відео недоступне (видалене, приватне або не існує)."
+    ),
+    DownloadErrorKind.GEO_BLOCKED: "🌍 Відео недоступне у цьому регіоні.",
+    DownloadErrorKind.RATE_LIMITED: (
+        "⏳ Забагато запитів до сайту. Спробуй, будь ласка, трохи згодом."
+    ),
+    DownloadErrorKind.UNSUPPORTED: "❓ Це посилання не підтримується.",
+    DownloadErrorKind.NETWORK: (
+        "📡 Проблема з мережею під час завантаження. Спробуй ще раз."
+    ),
+    DownloadErrorKind.EXTRACTION: (
+        "⚠️ Сайт тимчасово не віддає відео. Спробуй ще раз за хвилину."
+    ),
+}
+
+
+def classify_download_error(msg: str) -> DownloadErrorKind:
+    """Map a yt-dlp error message to a DownloadErrorKind (first match wins)."""
+    low = msg.lower()
+    for kind, markers in _ERROR_KIND_MARKERS:
+        if any(marker in low for marker in markers):
+            return kind
+    return DownloadErrorKind.UNKNOWN
 
 
 def _is_retriable_error(msg: str) -> bool:
-    """True if the yt-dlp error message looks like a transient, retriable one."""
-    low = msg.lower()
-    return any(marker in low for marker in _RETRIABLE_MARKERS)
+    """True if the error is a transient kind worth retrying."""
+    return classify_download_error(msg) in _RETRIABLE_KINDS
+
+
+def _user_message_for_error(error) -> str:
+    """A friendly, kind-aware Ukrainian message for a download error."""
+    kind = classify_download_error(str(error))
+    return _ERROR_USER_MESSAGES.get(kind, f"Download error: {error}")
 
 
 # Network/extractor robustness defaults shared by every yt-dlp call.
@@ -263,6 +399,7 @@ class Bot_Func:
                 "reason": reason,
                 "url": url,
                 "error": str(error) if error else None,
+                "kind": classify_download_error(str(error)).value if error else None,
                 "user_id": user_id,
                 "chat_id": chat_id,
                 "yt_dlp": getattr(getattr(yt_dlp, "version", None), "__version__", "?"),
@@ -423,7 +560,7 @@ class Bot_Func:
             self.log.success(f"✅ Download successful! {loc_video}")
             self._log_media_info(media_info)
         except yt_dlp.utils.DownloadError as e:
-            self.log.error(f"❌ Download error: {e}")
+            self.log.error(f"❌ Download error [{classify_download_error(str(e)).value}]: {e}")
             self._record_download_issue(
                 med_url,
                 "download_error",
@@ -434,7 +571,7 @@ class Bot_Func:
             )
             if strt_dwn_msg:
                 await strt_dwn_msg.delete()
-            await user_msg.reply(f"Download error: {e}")
+            await user_msg.reply(_user_message_for_error(e))
             return
         except Exception as e:
             self.log.error(f"❌ An error occurred: {e}")

--- a/src/bot.py
+++ b/src/bot.py
@@ -44,87 +44,68 @@ class DownloadErrorKind(Enum):
 # Ordered most-specific → most-generic: the first kind with a matching
 # substring wins, so AGE/LOGIN/UNAVAILABLE are checked before the broad
 # EXTRACTION markers. Match is a case-insensitive substring of the message.
-_ERROR_KIND_MARKERS: tuple[tuple[DownloadErrorKind, tuple[str, ...]], ...] = (
-    (
-        DownloadErrorKind.AGE_RESTRICTED,
-        (
-            "confirm your age",
-            "age-restricted",
-            "age restricted",
-            "inappropriate for some users",
-        ),
+_ERROR_KIND_MARKERS: dict[DownloadErrorKind, tuple[str, ...]] = {
+    DownloadErrorKind.AGE_RESTRICTED: (
+        "confirm your age",
+        "age-restricted",
+        "age restricted",
+        "inappropriate for some users",
     ),
-    (
-        DownloadErrorKind.LOGIN_REQUIRED,
-        (
-            "sign in to confirm you're not a bot",
-            "sign in",
-            "log in to",
-            "login required",
-            "requires authentication",
-            "private video",
-            "this video is private",
-            "this account is private",
-            "use --cookies",
-        ),
+    DownloadErrorKind.LOGIN_REQUIRED: (
+        "sign in to confirm you're not a bot",
+        "sign in",
+        "log in to",
+        "login required",
+        "requires authentication",
+        "private video",
+        "this video is private",
+        "this account is private",
+        "use --cookies",
     ),
-    (
-        DownloadErrorKind.GEO_BLOCKED,
-        (
-            "not available in your country",
-            "in your country",
-            "geo restricted",
-            "geo-restricted",
-        ),
+    DownloadErrorKind.GEO_BLOCKED: (
+        "not available in your country",
+        "in your country",
+        "geo restricted",
+        "geo-restricted",
     ),
-    (
-        DownloadErrorKind.RATE_LIMITED,
-        ("http error 429", "too many requests", "rate-limit", "rate limit"),
+    DownloadErrorKind.RATE_LIMITED: (
+        "http error 429",
+        "too many requests",
+        "rate-limit",
+        "rate limit",
     ),
-    (
-        DownloadErrorKind.UNAVAILABLE,
-        (
-            "video unavailable",
-            "no longer available",
-            "has been removed",
-            "was deleted",
-            "this post may not be available",
-            "http error 404",
-            "account has been terminated",
-        ),
+    DownloadErrorKind.UNAVAILABLE: (
+        "video unavailable",
+        "no longer available",
+        "has been removed",
+        "was deleted",
+        "this post may not be available",
+        "http error 404",
+        "account has been terminated",
     ),
-    (
-        DownloadErrorKind.UNSUPPORTED,
-        (
-            "unsupported url",
-            "no suitable extractor",
-            "no video formats found",
-            "is not a valid url",
-        ),
+    DownloadErrorKind.UNSUPPORTED: (
+        "unsupported url",
+        "no suitable extractor",
+        "no video formats found",
+        "is not a valid url",
     ),
-    (
-        DownloadErrorKind.NETWORK,
-        (
-            "timed out",
-            "timeout",
-            "read timed out",
-            "connection",
-            "temporarily",
-            "http error 5",
-            "remote end closed",
-        ),
+    DownloadErrorKind.NETWORK: (
+        "timed out",
+        "timeout",
+        "read timed out",
+        "connection",
+        "temporarily",
+        "http error 5",
+        "remote end closed",
     ),
-    (
-        DownloadErrorKind.EXTRACTION,
-        (
-            "rehydration",
-            "universal data",
-            "unable to extract",
-            "unable to download webpage",
-            "challenge",
-        ),
+    DownloadErrorKind.EXTRACTION: (
+        "rehydration",
+        "universal data",
+        "unable to extract",
+        "unable to download webpage",
+        "challenge",
     ),
-)
+}
 
 # Kinds where retrying has a real chance of succeeding.
 _RETRIABLE_KINDS = frozenset(
@@ -164,7 +145,7 @@ _ERROR_USER_MESSAGES = {
 def classify_download_error(msg: str) -> DownloadErrorKind:
     """Map a yt-dlp error message to a DownloadErrorKind (first match wins)."""
     low = msg.lower()
-    for kind, markers in _ERROR_KIND_MARKERS:
+    for kind, markers in _ERROR_KIND_MARKERS.items():
         if any(marker in low for marker in markers):
             return kind
     return DownloadErrorKind.UNKNOWN
@@ -173,12 +154,6 @@ def classify_download_error(msg: str) -> DownloadErrorKind:
 def _is_retriable_error(msg: str) -> bool:
     """True if the error is a transient kind worth retrying."""
     return classify_download_error(msg) in _RETRIABLE_KINDS
-
-
-def _user_message_for_error(error) -> str:
-    """A friendly, kind-aware Ukrainian message for a download error."""
-    kind = classify_download_error(str(error))
-    return _ERROR_USER_MESSAGES.get(kind, f"Download error: {error}")
 
 
 # Network/extractor robustness defaults shared by every yt-dlp call.
@@ -384,14 +359,24 @@ class Bot_Func:
         return ""
 
     def _record_download_issue(
-        self, url, reason, media_info=None, error=None, chat_id=None, user_id=None
+        self,
+        url,
+        reason,
+        media_info=None,
+        error=None,
+        chat_id=None,
+        user_id=None,
+        kind=None,
     ) -> None:
         """Append a JSONL record (logs/download_issues.jsonl) for a failed or
         audioless download, so the problem can be understood and reproduced.
 
         ``chat_id`` is where it happened (may be a group); ``user_id`` is who
-        triggered it (the real person, passed in by the handler)."""
+        triggered it (the real person, passed in by the handler). ``kind`` is the
+        pre-classified DownloadErrorKind; if omitted it's derived from ``error``."""
         try:
+            if kind is None and error is not None:
+                kind = classify_download_error(str(error))
             vcodec, acodec = _codecs_of(media_info)
             src = _source_stream_dict(media_info)
             record = {
@@ -399,7 +384,7 @@ class Bot_Func:
                 "reason": reason,
                 "url": url,
                 "error": str(error) if error else None,
-                "kind": classify_download_error(str(error)).value if error else None,
+                "kind": kind.value if kind else None,
                 "user_id": user_id,
                 "chat_id": chat_id,
                 "yt_dlp": getattr(getattr(yt_dlp, "version", None), "__version__", "?"),
@@ -560,7 +545,8 @@ class Bot_Func:
             self.log.success(f"✅ Download successful! {loc_video}")
             self._log_media_info(media_info)
         except yt_dlp.utils.DownloadError as e:
-            self.log.error(f"❌ Download error [{classify_download_error(str(e)).value}]: {e}")
+            kind = classify_download_error(str(e))
+            self.log.error(f"❌ Download error [{kind.value}]: {e}")
             self._record_download_issue(
                 med_url,
                 "download_error",
@@ -568,10 +554,11 @@ class Bot_Func:
                 error=e,
                 chat_id=chat_id,
                 user_id=user_id,
+                kind=kind,
             )
             if strt_dwn_msg:
                 await strt_dwn_msg.delete()
-            await user_msg.reply(_user_message_for_error(e))
+            await user_msg.reply(_ERROR_USER_MESSAGES.get(kind, f"Download error: {e}"))
             return
         except Exception as e:
             self.log.error(f"❌ An error occurred: {e}")

--- a/src/bot.py
+++ b/src/bot.py
@@ -42,6 +42,23 @@ class Bot_Func:
         self.log = log
         self.root_prj = root_prj
 
+    def search_youtube(self, query, max_results=5):
+        """Search YouTube using yt-dlp and return up to max_results entries."""
+        ydl_opts = {
+            'quiet': True,
+            'extract_flat': True,
+            'force_generic_extractor': False,
+        }
+        try:
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                result = ydl.extract_info(
+                    f"ytsearch{max_results}:{query}", download=False
+                )
+                return result.get('entries', [])
+        except Exception as e:
+            self.log.error(f"YouTube search error: {e}")
+            return []
+
 
 
     # TODO: remove from main

--- a/src/bot.py
+++ b/src/bot.py
@@ -244,10 +244,13 @@ class Bot_Func:
         return ""
 
     def _record_download_issue(
-        self, url, reason, media_info=None, error=None, chat_id=None
+        self, url, reason, media_info=None, error=None, chat_id=None, user_id=None
     ) -> None:
         """Append a JSONL record (logs/download_issues.jsonl) for a failed or
-        audioless download, so the problem can be understood and reproduced."""
+        audioless download, so the problem can be understood and reproduced.
+
+        ``chat_id`` is where it happened (may be a group); ``user_id`` is who
+        triggered it (the real person, passed in by the handler)."""
         try:
             vcodec, acodec = _codecs_of(media_info)
             src = ((media_info or {}).get("requested_downloads") or [{}])[0] or (
@@ -258,6 +261,7 @@ class Bot_Func:
                 "reason": reason,
                 "url": url,
                 "error": str(error) if error else None,
+                "user_id": user_id,
                 "chat_id": chat_id,
                 "yt_dlp": getattr(getattr(yt_dlp, "version", None), "__version__", "?"),
                 "extractor": (media_info or {}).get("extractor_key"),
@@ -275,10 +279,12 @@ class Bot_Func:
         except Exception as e:
             self.log.error(f"Failed to record download issue: {e}")
 
-    async def get_dwn_media(self, ydl_opts, user_msg, youtubeLink=""):
+    async def get_dwn_media(self, ydl_opts, user_msg, youtubeLink="", user_id=None):
         med_url = youtubeLink if youtubeLink else user_msg.text
 
         loc_video = ydl_opts["outtmpl"]
+        # chat_id = where it happened (can be a group); user_id = who (passed by
+        # the handler, since for bot-sent messages user_msg.from_user is the bot).
         chat_id = getattr(getattr(user_msg, "chat", None), "id", None)
 
         strt_dwn_msg = None
@@ -385,6 +391,7 @@ class Bot_Func:
                     "video_without_audio",
                     media_info=media_info,
                     chat_id=chat_id,
+                    user_id=user_id,
                 )
                 silent = self._resolve_downloaded_file(loc_video, finished_file)
                 if silent:
@@ -396,6 +403,19 @@ class Bot_Func:
                     "format": "best[acodec!=none][vcodec!=none]/best",
                 }
                 media_info = await asyncio.to_thread(download, combined_opts)
+                # If the combined refetch is *still* silent, don't let it pass
+                # unnoticed — record it so the blind spot stays diagnosable.
+                if _is_video_without_audio(media_info):
+                    self.log.error(
+                        "❌ Still no audio after combined-format refetch"
+                    )
+                    self._record_download_issue(
+                        med_url,
+                        "still_no_audio_after_recovery",
+                        media_info=media_info,
+                        chat_id=chat_id,
+                        user_id=user_id,
+                    )
 
             await strt_dwn_msg.delete()
             self.log.success(f"✅ Download successful! {loc_video}")
@@ -408,6 +428,7 @@ class Bot_Func:
                 media_info=media_info,
                 error=e,
                 chat_id=chat_id,
+                user_id=user_id,
             )
             if strt_dwn_msg:
                 await strt_dwn_msg.delete()
@@ -425,7 +446,11 @@ class Bot_Func:
         if not resolved:
             self.log.error(f"Download finished but file not found. {loc_video=}")
             self._record_download_issue(
-                med_url, "file_not_found", media_info=media_info, chat_id=chat_id
+                med_url,
+                "file_not_found",
+                media_info=media_info,
+                chat_id=chat_id,
+                user_id=user_id,
             )
             await user_msg.reply(f"Download finished but file not found. {loc_video=}")
             return

--- a/src/bot.py
+++ b/src/bot.py
@@ -69,11 +69,19 @@ def _cleanup_partial_downloads(base: str) -> None:
                 os.remove(leftover)
 
 
+def _source_stream_dict(media_info: dict | None) -> dict:
+    """The actually-downloaded stream dict. yt-dlp puts merged/remuxed stream
+    data under ``requested_downloads[0]``; fall back to the top-level info."""
+    if not media_info:
+        return {}
+    return (media_info.get("requested_downloads") or [{}])[0] or media_info
+
+
 def _codecs_of(media_info: dict | None) -> tuple[str, str]:
     """Return (vcodec, acodec) of the actually-downloaded stream, lowercased."""
     if not media_info:
         return "", ""
-    src = (media_info.get("requested_downloads") or [{}])[0] or media_info
+    src = _source_stream_dict(media_info)
     vcodec = ((src.get("vcodec") or media_info.get("vcodec")) or "").lower()
     acodec = ((src.get("acodec") or media_info.get("acodec")) or "").lower()
     return vcodec, acodec
@@ -118,11 +126,7 @@ class Bot_Func:
         """Log codec/resolution/bitrate and return the same text for sidecar writing."""
         if not info:
             return ""
-        # For merged/remuxed formats the final stream data lives under
-        # requested_downloads[0]; fall back to top-level info_dict fields.
-        rd = (info.get("requested_downloads") or [{}])[0]
-        src = rd if rd else info
-
+        src = _source_stream_dict(info)
         vcodec = src.get("vcodec") or info.get("vcodec", "?")
         acodec = src.get("acodec") or info.get("acodec", "?")
         width = src.get("width") or info.get("width")
@@ -253,9 +257,7 @@ class Bot_Func:
         triggered it (the real person, passed in by the handler)."""
         try:
             vcodec, acodec = _codecs_of(media_info)
-            src = ((media_info or {}).get("requested_downloads") or [{}])[0] or (
-                media_info or {}
-            )
+            src = _source_stream_dict(media_info)
             record = {
                 "ts": datetime.now().isoformat(timespec="seconds"),
                 "reason": reason,

--- a/src/bot.py
+++ b/src/bot.py
@@ -164,10 +164,11 @@ class Bot_Func:
             await user_msg.reply(f"The video file does not exist. {loc_video=}")
             return
 
-        # Write sidecar .txt with download date
-        sidecar = os.path.splitext(loc_video)[0] + ".txt"
-        with open(sidecar, "w") as f:
-            f.write(datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+        # Write sidecar .txt named {title}__{date}.txt
+        date_str = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        stem = os.path.splitext(loc_video)[0]
+        sidecar = f"{stem}__{date_str}.txt"
+        open(sidecar, "w").close()
 
         self.log.info(f"File size: {ut.h_readable(os.path.getsize(loc_video))}")
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -69,6 +69,63 @@ class Bot_Func:
         self.log.info(line)
         return "\n".join([line, f"url: {url}", f"title: {title}"])
 
+    # Codecs natively supported on Apple (iOS / macOS / Safari)
+    _APPLE_VCODECS = (
+        "avc",
+        "h264",
+        "hvc",
+        "hevc",
+        "h265",
+        "av1",
+    )  # av1 on newer devices
+
+    async def _ensure_h264(self, path: str, media_info: dict | None, user_msg) -> str:
+        """Transcode to H.264/AAC if the video codec is not Apple-compatible."""
+        if not media_info:
+            return path
+        rd = (media_info.get("requested_downloads") or [{}])[0]
+        vcodec = ((rd.get("vcodec") or media_info.get("vcodec")) or "").lower()
+        if not vcodec or vcodec.startswith(self._APPLE_VCODECS):
+            return path  # already fine
+
+        self.log.warning(
+            f"⚠️ Codec {vcodec!r} not Apple-compatible — transcoding to H.264"
+        )
+        try:
+            await user_msg.answer("⚙️ Converting to H.264 for Apple compatibility…")
+        except Exception:
+            pass
+
+        out_path = os.path.splitext(path)[0] + ".h264.mp4"
+        proc = await asyncio.create_subprocess_exec(
+            "ffmpeg",
+            "-y",
+            "-i",
+            path,
+            "-c:v",
+            "libx264",
+            "-preset",
+            "fast",
+            "-crf",
+            "23",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
+            "-movflags",
+            "+faststart",
+            out_path,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            self.log.error(f"Transcode failed: {stderr.decode()[-500:]}")
+            return path  # send original, let the caller deal with it
+        os.remove(path)
+        self.log.success(f"✅ Transcoded to H.264: {out_path}")
+        return out_path
+
     def extract_video_info(self, url):
         """Extract video metadata (title, thumbnail, duration). Blocking."""
         try:
@@ -205,6 +262,9 @@ class Bot_Func:
             await user_msg.reply(f"Download finished but file not found. {loc_video=}")
             return
         loc_video = resolved
+
+        # Transcode to H.264 if codec is not Apple-compatible (VP9, AV1, etc.)
+        loc_video = await self._ensure_h264(loc_video, media_info, user_msg)
 
         # Write sidecar .txt named {title}__{date}.txt
         date_str = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")

--- a/src/bot.py
+++ b/src/bot.py
@@ -2,6 +2,7 @@
 from src import utils as ut
 import contextlib
 import glob
+import json
 import re
 from datetime import datetime
 from pathlib import Path
@@ -66,6 +67,22 @@ def _cleanup_partial_downloads(base: str) -> None:
         if leftover.endswith((".part", ".ytdl")):
             with contextlib.suppress(OSError):
                 os.remove(leftover)
+
+
+def _codecs_of(media_info: dict | None) -> tuple[str, str]:
+    """Return (vcodec, acodec) of the actually-downloaded stream, lowercased."""
+    if not media_info:
+        return "", ""
+    src = (media_info.get("requested_downloads") or [{}])[0] or media_info
+    vcodec = ((src.get("vcodec") or media_info.get("vcodec")) or "").lower()
+    acodec = ((src.get("acodec") or media_info.get("acodec")) or "").lower()
+    return vcodec, acodec
+
+
+def _is_video_without_audio(media_info: dict | None) -> bool:
+    """True only when we *know* it's a video stream with no audio track."""
+    vcodec, acodec = _codecs_of(media_info)
+    return vcodec not in ("", "none") and acodec == "none"
 
 
 vid_format_dict = {
@@ -137,8 +154,7 @@ class Bot_Func:
         """Transcode to H.264/AAC if the video codec is not Apple-compatible."""
         if not media_info:
             return path
-        rd = (media_info.get("requested_downloads") or [{}])[0]
-        vcodec = ((rd.get("vcodec") or media_info.get("vcodec")) or "").lower()
+        vcodec, _ = _codecs_of(media_info)
         # "none" == audio-only download (mp3 etc.): nothing to transcode.
         if not vcodec or vcodec == "none" or vcodec.startswith(self._APPLE_VCODECS):
             return path  # already fine
@@ -208,10 +224,61 @@ class Bot_Func:
             self.log.error(f"YouTube search error: {e}")
             return []
 
+    def _resolve_downloaded_file(self, outtmpl: str, finished_file: str) -> str:
+        """Find the real downloaded file: hook result first, then glob fallback."""
+        if finished_file and os.path.exists(finished_file):
+            return finished_file
+        base_path = _strip_outtmpl_vars(outtmpl)
+        if base_path.endswith("/"):
+            # Template was directory-only — pick newest non-part file in dir.
+            candidates = [
+                f
+                for f in glob.glob(os.path.join(base_path, "*"))
+                if not f.endswith(".part") and os.path.isfile(f)
+            ]
+            return max(candidates, key=os.path.getmtime) if candidates else ""
+        if base_path:
+            loc_match = glob.glob(os.path.join(".", glob.escape(base_path) + "*"))
+            if loc_match:
+                return loc_match[0]
+        return ""
+
+    def _record_download_issue(
+        self, url, reason, media_info=None, error=None, chat_id=None
+    ) -> None:
+        """Append a JSONL record (logs/download_issues.jsonl) for a failed or
+        audioless download, so the problem can be understood and reproduced."""
+        try:
+            vcodec, acodec = _codecs_of(media_info)
+            src = (media_info or {}).get("requested_downloads") or [{}]
+            src = src[0] or (media_info or {})
+            record = {
+                "ts": datetime.now().isoformat(timespec="seconds"),
+                "reason": reason,
+                "url": url,
+                "error": str(error) if error else None,
+                "chat_id": chat_id,
+                "yt_dlp": getattr(getattr(yt_dlp, "version", None), "__version__", "?"),
+                "extractor": (media_info or {}).get("extractor_key"),
+                "format_id": src.get("format_id"),
+                "vcodec": vcodec or None,
+                "acodec": acodec or None,
+                "ext": src.get("ext"),
+                "filesize": src.get("filesize") or src.get("filesize_approx"),
+            }
+            path = self.root_prj / "logs" / "download_issues.jsonl"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+            self.log.info(f"📝 Recorded download issue ({reason}) → {path}")
+        except Exception as e:
+            self.log.error(f"Failed to record download issue: {e}")
+
     async def get_dwn_media(self, ydl_opts, user_msg, youtubeLink=""):
         med_url = youtubeLink if youtubeLink else user_msg.text
 
         loc_video = ydl_opts["outtmpl"]
+        chat_id = getattr(getattr(user_msg, "chat", None), "id", None)
 
         strt_dwn_msg = None
         finished_file: str = ""
@@ -273,7 +340,7 @@ class Bot_Func:
                 "postprocessor_hooks": [pp_hook],
             }
 
-            def download():
+            def download(opts):
                 # Retry transient failures (TikTok rehydration flakiness, timeouts,
                 # transient network errors). The same link that fails once usually
                 # succeeds on the next attempt — see logs in the bug report. The
@@ -282,7 +349,7 @@ class Bot_Func:
                 base = _strip_outtmpl_vars(loc_video)
                 for attempt in range(1, MAX_DOWNLOAD_ATTEMPTS + 1):
                     try:
-                        with yt_dlp.YoutubeDL(ydl_opts_with_hook) as ydl:
+                        with yt_dlp.YoutubeDL(opts) as ydl:
                             return ydl.extract_info(med_url, download=True)
                     except yt_dlp.utils.DownloadError as e:
                         if attempt >= MAX_DOWNLOAD_ATTEMPTS or not _is_retriable_error(
@@ -303,12 +370,44 @@ class Bot_Func:
                         _cleanup_partial_downloads(base)
                         time.sleep(RETRY_BASE_DELAY * attempt)
 
-            media_info = await asyncio.to_thread(download)
+            media_info = await asyncio.to_thread(download, ydl_opts_with_hook)
+
+            # Some sites (notably TikTok) occasionally hand back a video-only
+            # stream, so the result has no sound. Re-fetch once forcing a
+            # combined audio+video format. (Bug report: "sometimes no audio".)
+            if _is_video_without_audio(media_info):
+                self.log.warning(
+                    "⚠️ Downloaded video has no audio — refetching combined format"
+                )
+                self._record_download_issue(
+                    med_url,
+                    "video_without_audio",
+                    media_info=media_info,
+                    chat_id=chat_id,
+                )
+                silent = self._resolve_downloaded_file(loc_video, finished_file)
+                if silent:
+                    ut.delete_video_file(silent)
+                _cleanup_partial_downloads(_strip_outtmpl_vars(loc_video))
+                finished_file = ""
+                combined_opts = {
+                    **ydl_opts_with_hook,
+                    "format": "best[acodec!=none][vcodec!=none]/best",
+                }
+                media_info = await asyncio.to_thread(download, combined_opts)
+
             await strt_dwn_msg.delete()
             self.log.success(f"✅ Download successful! {loc_video}")
             self._log_media_info(media_info)
         except yt_dlp.utils.DownloadError as e:
             self.log.error(f"❌ Download error: {e}")
+            self._record_download_issue(
+                med_url,
+                "download_error",
+                media_info=media_info,
+                error=e,
+                chat_id=chat_id,
+            )
             if strt_dwn_msg:
                 await strt_dwn_msg.delete()
             await user_msg.reply(f"Download error: {e}")
@@ -320,29 +419,13 @@ class Bot_Func:
             await user_msg.reply(f"An error occurred: {e}")
             return
 
-        # Resolve actual file path: prefer postprocessor-hook result, then
-        # progress-hook result, then glob fallback.
-        resolved: str = ""
-        if finished_file and os.path.exists(finished_file):
-            resolved = finished_file
-        else:
-            base_path = _strip_outtmpl_vars(loc_video)
-            if base_path.endswith("/"):
-                # Template was directory-only — pick newest non-part file in dir
-                candidates = [
-                    f
-                    for f in glob.glob(os.path.join(base_path, "*"))
-                    if not f.endswith(".part") and os.path.isfile(f)
-                ]
-                if candidates:
-                    resolved = max(candidates, key=os.path.getmtime)
-            elif base_path:
-                loc_match = glob.glob(os.path.join(".", glob.escape(base_path) + "*"))
-                if loc_match:
-                    resolved = loc_match[0]
-
+        # Resolve actual file path (hook result first, then glob fallback).
+        resolved = self._resolve_downloaded_file(loc_video, finished_file)
         if not resolved:
             self.log.error(f"Download finished but file not found. {loc_video=}")
+            self._record_download_issue(
+                med_url, "file_not_found", media_info=media_info, chat_id=chat_id
+            )
             await user_msg.reply(f"Download finished but file not found. {loc_video=}")
             return
         loc_video = resolved

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,5 +1,6 @@
 # import utils as ut
 from src import utils as ut
+import contextlib
 import glob
 import re
 from datetime import datetime
@@ -41,6 +42,30 @@ def _is_retriable_error(msg: str) -> bool:
     """True if the yt-dlp error message looks like a transient, retriable one."""
     low = msg.lower()
     return any(marker in low for marker in _RETRIABLE_MARKERS)
+
+
+# Network/extractor robustness defaults shared by every yt-dlp call.
+_YDL_ROBUSTNESS_OPTS = {
+    "retries": 5,
+    "fragment_retries": 5,
+    "extractor_retries": 3,
+    "socket_timeout": 30,
+}
+
+
+def _strip_outtmpl_vars(template: str) -> str:
+    """Strip yt-dlp template vars (e.g. ".%(ext)s") to get the base path/prefix."""
+    return re.sub(r"\.?%\([^)]+\)s", "", template)
+
+
+def _cleanup_partial_downloads(base: str) -> None:
+    """Remove ``.part``/``.ytdl`` artifacts left by an interrupted yt-dlp run."""
+    if not base:
+        return
+    for leftover in glob.glob(glob.escape(base) + "*"):
+        if leftover.endswith((".part", ".ytdl")):
+            with contextlib.suppress(OSError):
+                os.remove(leftover)
 
 
 vid_format_dict = {
@@ -159,12 +184,7 @@ class Bot_Func:
     def extract_video_info(self, url):
         """Extract video metadata (title, thumbnail, duration). Blocking."""
         try:
-            opts = {
-                "quiet": True,
-                "skip_download": True,
-                "extractor_retries": 3,
-                "socket_timeout": 30,
-            }
+            opts = {"quiet": True, "skip_download": True, **_YDL_ROBUSTNESS_OPTS}
             with yt_dlp.YoutubeDL(opts) as ydl:
                 info = ydl.extract_info(url, download=False)
                 return {
@@ -246,12 +266,8 @@ class Bot_Func:
                     pass
 
             ydl_opts_with_hook = {
-                # Network/extractor robustness defaults — caller's ydl_opts may
-                # override any of these via the spread below.
-                "retries": 5,
-                "fragment_retries": 5,
-                "extractor_retries": 3,
-                "socket_timeout": 30,
+                # Robustness defaults — caller's ydl_opts may override via spread.
+                **_YDL_ROBUSTNESS_OPTS,
                 **ydl_opts,
                 "progress_hooks": [progress_hook],
                 "postprocessor_hooks": [pp_hook],
@@ -260,15 +276,15 @@ class Bot_Func:
             def download():
                 # Retry transient failures (TikTok rehydration flakiness, timeouts,
                 # transient network errors). The same link that fails once usually
-                # succeeds on the next attempt — see logs in the bug report.
-                base = re.sub(r"\.?%\([^)]+\)s", "", loc_video)
-                last_err = None
+                # succeeds on the next attempt — see logs in the bug report. The
+                # final attempt re-raises (attempt >= MAX), so the loop never falls
+                # through.
+                base = _strip_outtmpl_vars(loc_video)
                 for attempt in range(1, MAX_DOWNLOAD_ATTEMPTS + 1):
                     try:
                         with yt_dlp.YoutubeDL(ydl_opts_with_hook) as ydl:
                             return ydl.extract_info(med_url, download=True)
                     except yt_dlp.utils.DownloadError as e:
-                        last_err = e
                         if attempt >= MAX_DOWNLOAD_ATTEMPTS or not _is_retriable_error(
                             str(e)
                         ):
@@ -284,18 +300,8 @@ class Bot_Func:
                             ),
                             loop,
                         )
-                        # Drop half-downloaded leftovers before the next attempt.
-                        if base:
-                            for leftover in glob.glob(glob.escape(base) + "*"):
-                                if leftover.endswith((".part", ".ytdl")):
-                                    try:
-                                        os.remove(leftover)
-                                    except OSError:
-                                        pass
+                        _cleanup_partial_downloads(base)
                         time.sleep(RETRY_BASE_DELAY * attempt)
-                # Exhausted retries — re-raise for the outer DownloadError handler.
-                if last_err:
-                    raise last_err
 
             media_info = await asyncio.to_thread(download)
             await strt_dwn_msg.delete()
@@ -320,7 +326,7 @@ class Bot_Func:
         if finished_file and os.path.exists(finished_file):
             resolved = finished_file
         else:
-            base_path = re.sub(r"\.?%\([^)]+\)s", "", loc_video)
+            base_path = _strip_outtmpl_vars(loc_video)
             if base_path.endswith("/"):
                 # Template was directory-only — pick newest non-part file in dir
                 candidates = [

--- a/src/bot.py
+++ b/src/bot.py
@@ -3,6 +3,7 @@ from src import utils as ut
 import glob
 import re
 from datetime import datetime
+from pathlib import Path
 import yt_dlp
 import os
 import asyncio
@@ -74,7 +75,7 @@ class Bot_Func:
         loc_video = ydl_opts["outtmpl"]
 
         strt_dwn_msg = None
-        finished_files: list[str] = []
+        finished_file: str = ""
         try:
             strt_dwn_msg = await user_msg.answer("Downloading... 0%\n⬜⬜⬜⬜⬜⬜⬜⬜")
             self.log.debug(f"Start download video {loc_video}")
@@ -89,10 +90,9 @@ class Bot_Func:
                     pass
 
             def progress_hook(d):
+                nonlocal finished_file
                 if d["status"] == "finished":
-                    filename = d.get("filename", "")
-                    if filename:
-                        finished_files.append(filename)
+                    finished_file = d.get("filename", "")
                     return
                 if d["status"] != "downloading":
                     return
@@ -141,8 +141,8 @@ class Bot_Func:
             return
 
         # Resolve actual file path: prefer hook-captured name, fall back to glob
-        if finished_files and os.path.exists(finished_files[-1]):
-            loc_video = finished_files[-1]
+        if finished_file and os.path.exists(finished_file):
+            loc_video = finished_file
         else:
             base_path = re.sub(r"\.?%\([^)]+\)s", "", loc_video)
             if not base_path or base_path.endswith("/"):
@@ -150,8 +150,7 @@ class Bot_Func:
                     f"Download finished but file not found. {loc_video=}"
                 )
                 return
-            pattern = glob.escape(base_path) + "*"
-            loc_match = glob.glob(os.path.join(".", pattern))
+            loc_match = glob.glob(os.path.join(".", glob.escape(base_path) + "*"))
             if not loc_match:
                 await user_msg.reply(
                     f"Download finished but file not found. {loc_video=}"
@@ -159,16 +158,11 @@ class Bot_Func:
                 return
             loc_video = loc_match[0]
 
-        # Check if the file exists
-        if not os.path.exists(loc_video):
-            await user_msg.reply(f"The video file does not exist. {loc_video=}")
-            return
-
         # Write sidecar .txt named {title}__{date}.txt
         date_str = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        stem = os.path.splitext(loc_video)[0]
-        sidecar = f"{stem}__{date_str}.txt"
-        open(sidecar, "w").close()
+        stem, _ = ut.parse_media_filename(loc_video)
+        sidecar = f"{os.path.dirname(loc_video)}/{stem}__{date_str}.txt"
+        Path(sidecar).touch()
 
         self.log.info(f"File size: {ut.h_readable(os.path.getsize(loc_video))}")
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -89,6 +89,13 @@ class Bot_Func:
                 except Exception:
                     pass
 
+            def pp_hook(d):
+                nonlocal finished_file
+                if d["status"] == "finished":
+                    fp = d.get("info_dict", {}).get("filepath", "")
+                    if fp:
+                        finished_file = fp
+
             def progress_hook(d):
                 nonlocal finished_file
                 if d["status"] == "finished":
@@ -118,7 +125,11 @@ class Bot_Func:
                 except Exception:
                     pass
 
-            ydl_opts_with_hook = {**ydl_opts, "progress_hooks": [progress_hook]}
+            ydl_opts_with_hook = {
+                **ydl_opts,
+                "progress_hooks": [progress_hook],
+                "postprocessor_hooks": [pp_hook],
+            }
 
             def download():
                 with yt_dlp.YoutubeDL(ydl_opts_with_hook) as ydl:
@@ -140,23 +151,32 @@ class Bot_Func:
             await user_msg.reply(f"An error occurred: {e}")
             return
 
-        # Resolve actual file path: prefer hook-captured name, fall back to glob
+        # Resolve actual file path: prefer postprocessor-hook result, then
+        # progress-hook result, then glob fallback.
+        resolved: str = ""
         if finished_file and os.path.exists(finished_file):
-            loc_video = finished_file
+            resolved = finished_file
         else:
             base_path = re.sub(r"\.?%\([^)]+\)s", "", loc_video)
-            if not base_path or base_path.endswith("/"):
-                await user_msg.reply(
-                    f"Download finished but file not found. {loc_video=}"
-                )
-                return
-            loc_match = glob.glob(os.path.join(".", glob.escape(base_path) + "*"))
-            if not loc_match:
-                await user_msg.reply(
-                    f"Download finished but file not found. {loc_video=}"
-                )
-                return
-            loc_video = loc_match[0]
+            if base_path.endswith("/"):
+                # Template was directory-only — pick newest non-part file in dir
+                candidates = [
+                    f
+                    for f in glob.glob(os.path.join(base_path, "*"))
+                    if not f.endswith(".part") and os.path.isfile(f)
+                ]
+                if candidates:
+                    resolved = max(candidates, key=os.path.getmtime)
+            elif base_path:
+                loc_match = glob.glob(os.path.join(".", glob.escape(base_path) + "*"))
+                if loc_match:
+                    resolved = loc_match[0]
+
+        if not resolved:
+            self.log.error(f"Download finished but file not found. {loc_video=}")
+            await user_msg.reply(f"Download finished but file not found. {loc_video=}")
+            return
+        loc_video = resolved
 
         # Write sidecar .txt named {title}__{date}.txt
         date_str = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")

--- a/src/bot.py
+++ b/src/bot.py
@@ -114,7 +114,8 @@ class Bot_Func:
             return path
         rd = (media_info.get("requested_downloads") or [{}])[0]
         vcodec = ((rd.get("vcodec") or media_info.get("vcodec")) or "").lower()
-        if not vcodec or vcodec.startswith(self._APPLE_VCODECS):
+        # "none" == audio-only download (mp3 etc.): nothing to transcode.
+        if not vcodec or vcodec == "none" or vcodec.startswith(self._APPLE_VCODECS):
             return path  # already fine
 
         self.log.warning(
@@ -158,7 +159,13 @@ class Bot_Func:
     def extract_video_info(self, url):
         """Extract video metadata (title, thumbnail, duration). Blocking."""
         try:
-            with yt_dlp.YoutubeDL({"quiet": True, "skip_download": True}) as ydl:
+            opts = {
+                "quiet": True,
+                "skip_download": True,
+                "extractor_retries": 3,
+                "socket_timeout": 30,
+            }
+            with yt_dlp.YoutubeDL(opts) as ydl:
                 info = ydl.extract_info(url, download=False)
                 return {
                     "thumbnail": info.get("thumbnail", ""),

--- a/src/bot.py
+++ b/src/bot.py
@@ -250,8 +250,9 @@ class Bot_Func:
         audioless download, so the problem can be understood and reproduced."""
         try:
             vcodec, acodec = _codecs_of(media_info)
-            src = (media_info or {}).get("requested_downloads") or [{}]
-            src = src[0] or (media_info or {})
+            src = ((media_info or {}).get("requested_downloads") or [{}])[0] or (
+                media_info or {}
+            )
             record = {
                 "ts": datetime.now().isoformat(timespec="seconds"),
                 "reason": reason,

--- a/src/download_errors.py
+++ b/src/download_errors.py
@@ -1,0 +1,140 @@
+"""Classification of yt-dlp download failures.
+
+Pure, dependency-free logic (no yt-dlp / aiogram imports) so it can be unit
+tested in isolation. ``src.bot`` imports the public names from here.
+"""
+
+from enum import Enum
+
+
+class DownloadErrorKind(Enum):
+    """Category of a yt-dlp download failure, inferred from its error text.
+
+    Drives three things: whether we retry (transient kinds only), what message
+    the user sees, and how the failure is tagged in logs/download_issues.jsonl.
+    """
+
+    AGE_RESTRICTED = "age_restricted"  # site wants sign-in to confirm age
+    LOGIN_REQUIRED = "login_required"  # private / sign-in / bot-check
+    UNAVAILABLE = "unavailable"  # removed / deleted / private / not found
+    GEO_BLOCKED = "geo_blocked"  # not available in this country
+    RATE_LIMITED = "rate_limited"  # HTTP 429 / too many requests
+    UNSUPPORTED = "unsupported"  # unsupported URL / no extractor / no formats
+    NETWORK = "network"  # timeout / connection / 5xx (transient)
+    EXTRACTION = "extraction"  # rehydration / "unable to extract" (flaky)
+    UNKNOWN = "unknown"  # anything we could not classify
+
+
+# Ordered most-specific → most-generic: the first kind with a matching
+# substring wins, so AGE/LOGIN/UNAVAILABLE are checked before the broad
+# EXTRACTION markers. Match is a case-insensitive substring of the message.
+_ERROR_KIND_MARKERS: dict[DownloadErrorKind, tuple[str, ...]] = {
+    DownloadErrorKind.AGE_RESTRICTED: (
+        "confirm your age",
+        "age-restricted",
+        "age restricted",
+        "inappropriate for some users",
+    ),
+    DownloadErrorKind.LOGIN_REQUIRED: (
+        "sign in to confirm you're not a bot",
+        "sign in",
+        "log in to",
+        "login required",
+        "requires authentication",
+        "private video",
+        "this video is private",
+        "this account is private",
+        "use --cookies",
+    ),
+    DownloadErrorKind.GEO_BLOCKED: (
+        "not available in your country",
+        "in your country",
+        "geo restricted",
+        "geo-restricted",
+    ),
+    DownloadErrorKind.RATE_LIMITED: (
+        "http error 429",
+        "too many requests",
+        "rate-limit",
+        "rate limit",
+    ),
+    DownloadErrorKind.UNAVAILABLE: (
+        "video unavailable",
+        "no longer available",
+        "has been removed",
+        "was deleted",
+        "this post may not be available",
+        "http error 404",
+        "account has been terminated",
+    ),
+    DownloadErrorKind.UNSUPPORTED: (
+        "unsupported url",
+        "no suitable extractor",
+        "no video formats found",
+        "is not a valid url",
+    ),
+    DownloadErrorKind.NETWORK: (
+        "timed out",  # also covers "read timed out"
+        "timeout",
+        "connection",
+        "temporarily",
+        "http error 5",
+        "remote end closed",
+    ),
+    DownloadErrorKind.EXTRACTION: (
+        "rehydration",
+        "universal data",
+        "unable to extract",
+        "unable to download webpage",
+        "challenge",
+    ),
+}
+
+# Kinds where retrying has a real chance of succeeding.
+_RETRIABLE_KINDS = frozenset(
+    {
+        DownloadErrorKind.NETWORK,
+        DownloadErrorKind.EXTRACTION,
+        DownloadErrorKind.RATE_LIMITED,
+    }
+)
+
+# User-facing (Ukrainian) message per kind. Kinds absent here (e.g. UNKNOWN)
+# fall back to the raw error text at the call site.
+ERROR_USER_MESSAGES = {
+    DownloadErrorKind.AGE_RESTRICTED: (
+        "🔞 Відео з віковим обмеженням — сайт вимагає вхід/підтвердження віку, "
+        "тож завантажити не вдалося."
+    ),
+    DownloadErrorKind.LOGIN_REQUIRED: (
+        "🔒 Відео приватне або потребує входу — завантажити не можу."
+    ),
+    DownloadErrorKind.UNAVAILABLE: (
+        "🚫 Відео недоступне (видалене, приватне або не існує)."
+    ),
+    DownloadErrorKind.GEO_BLOCKED: "🌍 Відео недоступне у цьому регіоні.",
+    DownloadErrorKind.RATE_LIMITED: (
+        "⏳ Забагато запитів до сайту. Спробуй, будь ласка, трохи згодом."
+    ),
+    DownloadErrorKind.UNSUPPORTED: "❓ Це посилання не підтримується.",
+    DownloadErrorKind.NETWORK: (
+        "📡 Проблема з мережею під час завантаження. Спробуй ще раз."
+    ),
+    DownloadErrorKind.EXTRACTION: (
+        "⚠️ Сайт тимчасово не віддає відео. Спробуй ще раз за хвилину."
+    ),
+}
+
+
+def classify_download_error(msg: str) -> DownloadErrorKind:
+    """Map a yt-dlp error message to a DownloadErrorKind (first match wins)."""
+    low = msg.lower()
+    for kind, markers in _ERROR_KIND_MARKERS.items():
+        if any(marker in low for marker in markers):
+            return kind
+    return DownloadErrorKind.UNKNOWN
+
+
+def is_retriable_error(msg: str) -> bool:
+    """True if the error is a transient kind worth retrying."""
+    return classify_download_error(msg) in _RETRIABLE_KINDS

--- a/src/utils.py
+++ b/src/utils.py
@@ -14,6 +14,7 @@ from src.Users import UserTele, Level
 
 root_prj = Path(__file__).parent.parent.absolute()
 
+
 # get name or nickname from username or full_name something that exists in db
 def get_name_from_pydantic(user: UserTele) -> str:
     username = user.username
@@ -25,20 +26,22 @@ def get_name_from_pydantic(user: UserTele) -> str:
     else:
         return str(user.id)
 
+
 def progress_bar_str(current: float, max_value: float, length=8) -> str:
     percent = 100 * current / max_value
     percent = round(percent, 2)
     filled = int(length * current // max_value)
     filled = max(1, filled)
-    bar = '🟥' * filled + '🟩' * (length - filled)
-    return f'{bar} {percent} %'
+    bar = "🟥" * filled + "🟩" * (length - filled)
+    return f"{bar} {percent} %"
+
 
 def crt_cfg_params(cfg_params) -> dict:
-    cfg = load_config('configs/cfg.yml')
+    cfg = load_config("configs/cfg.yml")
     cfg_params_copy = edict(cfg_params.copy())
     res = edict()
     for key, value in cfg_params_copy.items():
-        keys = key.split('.')
+        keys = key.split(".")
         nested_dict = reduce(lambda d, key: d.get(key) if d else None, keys[:-1], cfg)
         if nested_dict:
             cfg_value = nested_dict.get(keys[-1])
@@ -52,7 +55,7 @@ def crt_cfg_params(cfg_params) -> dict:
     return res
 
 
-def load_config(config_path='configs/cfg.yml'):
+def load_config(config_path="configs/cfg.yml"):
     """
     Load configuration from a YAML file.
 
@@ -67,16 +70,15 @@ def load_config(config_path='configs/cfg.yml'):
     config = edict(config)
 
     shared_vars = config.shared_vars
-    shared_vars.update({'prj_root': os.getcwd()})
+    shared_vars.update({"prj_root": os.getcwd()})
     parse_config(config, shared_vars=shared_vars)
- 
 
     # shared_vars = config.shared_vars
     # TODO: change this hack
     # prj_root = str(Path(file).parent.parent)
     # shared_vars.update({'prj_root': os.path.normpath(prj_root)})
     # parse_config(config, shared_vars=shared_vars)
-    
+
     return config
 
 
@@ -93,24 +95,24 @@ def parse_config(cfg, shared_vars) -> None:
             # if new value is numeric
             if new_value.isnumeric():
                 new_value = int(new_value)
-                
+
             cfg[key] = new_value
- 
+
 
 def pydantic2pandas(user: UserTele) -> pd.DataFrame:
     user_df = pd.DataFrame([user.to_dict()])
     user_df = user_df.replace({np.nan: None})
-    user_df.set_index('id', inplace=True)
+    user_df.set_index("id", inplace=True)
     return user_df
 
 
 def pandas2pydentic(user_df: pd.DataFrame) -> UserTele:
     user_id = int(user_df.index[0])
-    user_dct = user_df.to_dict(orient='records')[0]
-    user_dct['id'] = user_id 
-    user_dct['level'] = Level.__members__.get((user_dct['level']).split('.')[-1])
+    user_dct = user_df.to_dict(orient="records")[0]
+    user_dct["id"] = user_id
+    user_dct["level"] = Level.__members__.get((user_dct["level"]).split(".")[-1])
 
-    user_tele : UserTele = UserTele.model_validate(user_dct)
+    user_tele: UserTele = UserTele.model_validate(user_dct)
 
     return user_tele
 
@@ -123,99 +125,116 @@ def create_empty_csv() -> pd.DataFrame:
     save_reg_user(user_df)
     return user_df
 
+
 def remove_non_ascii(text: str) -> str:
-    return re.sub(r'[^\x00-\x7F]+', '', text)
+    return re.sub(r"[^\x00-\x7F]+", "", text)
+
 
 def get_user_by_id(usr_id: int) -> pd.DataFrame:
-    users_reg_df: pd.DataFrame  = get_reg_users()
+    users_reg_df: pd.DataFrame = get_reg_users()
 
     if usr_id in users_reg_df.index:
-        logger.debug(f'User {usr_id} is already registered ')
+        logger.debug(f"User {usr_id} is already registered ")
         return users_reg_df.loc[[usr_id]]
     else:
-        logger.debug(f'User {usr_id} not in db')
+        logger.debug(f"User {usr_id} not in db")
         return pd.DataFrame()
 
 
-def update_row(user:UserTele) -> None:
+def update_row(user: UserTele) -> None:
     all_df = get_reg_users()
     user_row = pydantic2pandas(user)
-    logger.trace(f'{all_df=}, \n{user_row=}')
+    logger.trace(f"{all_df=}, \n{user_row=}")
     all_df.update(user_row)
     save_reg_user(all_df)
 
 
 def get_reg_users() -> pd.DataFrame:
-    reg_user_path = root_prj / 'data/reg_user.csv'
-    print(f'{reg_user_path.parent=}')
+    reg_user_path = root_prj / "data/reg_user.csv"
+    print(f"{reg_user_path.parent=}")
     reg_user_path.parent.mkdir(parents=True, exist_ok=True)
 
     if reg_user_path.is_file():
         df = pd.read_csv(reg_user_path)
-        if df.empty:     
-            logger.warning('Csv file is empty')
+        if df.empty:
+            logger.warning("Csv file is empty")
             return create_empty_csv()
-        
-        df= df.replace({np.nan: None})
-        df.set_index('id', inplace=True)
+
+        df = df.replace({np.nan: None})
+        df.set_index("id", inplace=True)
         return df
     else:
-        logger.warning('not exist')
+        logger.warning("not exist")
         return create_empty_csv()
-        
+
     # STEP_1: check if file exist
-    # if 
+    # if
     # STEP_2: if not create empty file and return empyy dataframe
     # STEP3: if exist, read csv dile and return DataFrame
     ...
 
 
 def save_reg_user(df: pd.DataFrame) -> None:
-    reg_user_path = root_prj / 'data/reg_user.csv'
+    reg_user_path = root_prj / "data/reg_user.csv"
     df.to_csv(reg_user_path)
-
 
 
 def setup_logger(LOGGER: loguru.logger, data_name="", log_dir=""):
     # Set up loguru
     timestr = time.strftime("%Y-%m-%d_%H:%M:%S")
-    logfile_name = f'tele_bot_{data_name}'
+    logfile_name = f"tele_bot_{data_name}"
     dir_logs = f"logs/{log_dir}"
     logfile_name = f"{dir_logs}/{logfile_name}_{timestr}.log"
     fmt = "{time:YYYY-MM-DD HH:mm:ss.SSS} | {name} | <level>{level}</level> | <level>{message}</level>"
     LOGGER.remove(0)
-    LOGGER.add(logfile_name,
-                level="DEBUG",
-                format=fmt,
-                colorize=False,
-                backtrace=False,
-                diagnose=True)
-    LOGGER.add(os.sys.stdout, level="TRACE", format=fmt, colorize=True, backtrace=True, diagnose=True)
+    LOGGER.add(
+        logfile_name,
+        level="DEBUG",
+        format=fmt,
+        colorize=False,
+        backtrace=False,
+        diagnose=True,
+    )
+    LOGGER.add(
+        os.sys.stdout,
+        level="TRACE",
+        format=fmt,
+        colorize=True,
+        backtrace=True,
+        diagnose=True,
+    )
 
     global logger
     logger = LOGGER
     return logger
 
 
-
 def expand_url(url: str) -> str:
     try:
         response = requests.head(url, allow_redirects=True)
         return response.url
-    except requests.RequestException as e:
+    except requests.RequestException:
         # logger.exception(f"Error expanding URL: {e}")
         return url
 
 
-def h_readable(file_size: int | float, unit='B') -> str:
+def h_readable(file_size: int | float, unit="B") -> str:
     if file_size > 1024 * 1024:
-        file_size /=  1024 * 1024
-        unit = 'MB'
+        file_size /= 1024 * 1024
+        unit = "MB"
     elif file_size > 1024:
         file_size /= 1024
-        unit = 'KB'
-    return f"{file_size:.2f} {unit}" if file_size > 0 else f'0 {unit} or less'
+        unit = "KB"
+    return f"{file_size:.2f} {unit}" if file_size > 0 else f"0 {unit} or less"
 
+
+def parse_media_filename(file_path: str) -> tuple[str, str]:
+    """Extract (title, ext) from a media file path.
+
+    Example: "media/123/My Video.mp4" → ("My Video", ".mp4")
+    """
+    stem, ext = os.path.splitext(os.path.basename(file_path))
+    return stem, ext
 
 
 def delete_video_file(file_path) -> None:
@@ -226,8 +245,14 @@ def delete_video_file(file_path) -> None:
             logger.info(f"The file {file_path} has been deleted successfully.")
         else:
             logger.warning(f"The file {file_path} does not exist.")
+        # Also remove the sidecar .txt with download date if present
+        sidecar = os.path.splitext(file_path)[0] + ".txt"
+        if os.path.exists(sidecar):
+            os.remove(sidecar)
     except Exception as e:
-        logger.error(f"An error occurred while trying to delete the file {file_path}: {e}")
+        logger.error(
+            f"An error occurred while trying to delete the file {file_path}: {e}"
+        )
 
 
 def get_file_size(file_path):
@@ -242,20 +267,26 @@ def get_file_size(file_path):
             logger.warning(f"The file {file_path} does not exist.")
             return None
     except Exception as e:
-        logger.error(f"An error occurred while trying to get the size of the file {file_path}: {e}")
+        logger.error(
+            f"An error occurred while trying to get the size of the file {file_path}: {e}"
+        )
         return None
 
 
-def cr_2_ln(sent:str) -> str:
+def cr_2_ln(sent: str) -> str:
     return cyrillic_to_latin(sent)
+
 
 def ln_2_cr(sent: str) -> str:
     return latin_to_cyrillic(sent)
 
-def is_ltn(sent:str) -> bool:
-    return bool(re.search(r'[a-zA-Z]', sent)) and not bool(re.search(r'[а-яА-ЯіІїЇєЄґҐ]', sent))
+
+def is_ltn(sent: str) -> bool:
+    return bool(re.search(r"[a-zA-Z]", sent)) and not bool(
+        re.search(r"[а-яА-ЯіІїЇєЄґҐ]", sent)
+    )
+
 
 def get_prj_root():
     root_path = Path.cwd()
     return root_path
-

--- a/src/utils.py
+++ b/src/utils.py
@@ -248,7 +248,7 @@ def delete_video_file(file_path) -> None:
             logger.warning(f"The file {file_path} does not exist.")
         # Also remove sidecar {stem}__{date}.txt if present
         stem = os.path.splitext(file_path)[0]
-        for sidecar in glob.glob(f"{stem}__*.txt"):
+        for sidecar in glob.glob(glob.escape(stem) + "__*.txt"):
             os.remove(sidecar)
     except Exception as e:
         logger.error(

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import glob
 import pandas as pd
 import requests
 import os
@@ -245,9 +246,9 @@ def delete_video_file(file_path) -> None:
             logger.info(f"The file {file_path} has been deleted successfully.")
         else:
             logger.warning(f"The file {file_path} does not exist.")
-        # Also remove the sidecar .txt with download date if present
-        sidecar = os.path.splitext(file_path)[0] + ".txt"
-        if os.path.exists(sidecar):
+        # Also remove sidecar {stem}__{date}.txt if present
+        stem = os.path.splitext(file_path)[0]
+        for sidecar in glob.glob(f"{stem}__*.txt"):
             os.remove(sidecar)
     except Exception as e:
         logger.error(

--- a/src/utils.py
+++ b/src/utils.py
@@ -156,7 +156,11 @@ def get_reg_users() -> pd.DataFrame:
     reg_user_path.parent.mkdir(parents=True, exist_ok=True)
 
     if reg_user_path.is_file():
-        df = pd.read_csv(reg_user_path)
+        try:
+            df = pd.read_csv(reg_user_path)
+        except pd.errors.EmptyDataError:
+            logger.warning("Csv file has no header (0-byte file)")
+            return create_empty_csv()
         if df.empty:
             logger.warning("Csv file is empty")
             return create_empty_csv()

--- a/tests/test_download_errors.py
+++ b/tests/test_download_errors.py
@@ -1,0 +1,102 @@
+"""Unit tests for src.download_errors.
+
+Pure logic — no yt-dlp / aiogram needed, so this runs standalone:
+    python tests/test_download_errors.py
+or under pytest:
+    pytest tests/test_download_errors.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.download_errors import (  # noqa: E402
+    DownloadErrorKind,
+    ERROR_USER_MESSAGES,
+    _ERROR_KIND_MARKERS,
+    classify_download_error,
+    is_retriable_error,
+)
+
+K = DownloadErrorKind
+
+# (yt-dlp-style message, expected kind, expected retriable)
+CASES = [
+    # The bot's real flaky error — must stay retriable.
+    (
+        "ERROR: [TikTok] 1: Unable to extract universal data for rehydration; "
+        "please report this issue on https://github.com/yt-dlp/yt-dlp/issues",
+        K.EXTRACTION,
+        True,
+    ),
+    (
+        "ERROR: Sign in to confirm your age. This video may be inappropriate "
+        "for some users.",
+        K.AGE_RESTRICTED,
+        False,
+    ),
+    ("ERROR: Sign in to confirm you're not a bot", K.LOGIN_REQUIRED, False),
+    ("ERROR: [instagram] This account is private", K.LOGIN_REQUIRED, False),
+    ("ERROR: Video unavailable. This video has been removed", K.UNAVAILABLE, False),
+    (
+        "ERROR: The uploader has not made this video available in your country",
+        K.GEO_BLOCKED,
+        False,
+    ),
+    ("ERROR: HTTP Error 429: Too Many Requests", K.RATE_LIMITED, True),
+    ("ERROR: Unsupported URL: https://example.com/x", K.UNSUPPORTED, False),
+    ("ERROR: Unable to download webpage: Read timed out.", K.NETWORK, True),
+    ("ERROR: <urlopen error [Errno 111] Connection refused>", K.NETWORK, True),
+    ("ERROR: HTTP Error 503: Service Unavailable", K.NETWORK, True),
+    ("ERROR: something we have never seen before", K.UNKNOWN, False),
+]
+
+
+def test_classification_and_retriability():
+    for msg, kind, retriable in CASES:
+        assert classify_download_error(msg) == kind, (msg, classify_download_error(msg))
+        assert is_retriable_error(msg) is retriable, (msg, is_retriable_error(msg))
+
+
+def test_case_insensitive():
+    assert classify_download_error("UNABLE TO EXTRACT something") == K.EXTRACTION
+
+
+def test_specific_kind_wins_over_later_generic():
+    # Ordering is load-bearing: a permanent AGE marker must win even though the
+    # message also contains a later EXTRACTION substring ("extract").
+    msg = "Sign in to confirm your age — also could not extract the page"
+    assert classify_download_error(msg) == K.AGE_RESTRICTED
+    assert is_retriable_error(msg) is False
+
+
+def test_read_timed_out_still_classifies_as_network():
+    # "read timed out" was removed as redundant; "timed out" still covers it.
+    assert classify_download_error("Read timed out.") == K.NETWORK
+
+
+def test_every_kind_except_unknown_has_markers_and_a_message():
+    for kind in DownloadErrorKind:
+        if kind is DownloadErrorKind.UNKNOWN:
+            continue
+        assert kind in _ERROR_KIND_MARKERS, f"{kind} has no markers"
+        assert kind in ERROR_USER_MESSAGES, f"{kind} has no user message"
+
+
+if __name__ == "__main__":
+    import traceback
+
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_"):
+            continue
+        try:
+            fn()
+            print(f"PASS  {name}")
+        except Exception:  # noqa: BLE001
+            failures += 1
+            print(f"FAIL  {name}")
+            traceback.print_exc()
+    print("ALL PASS" if not failures else f"{failures} TEST(S) FAILED")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Що це

PR із класифікацією помилок завантаження (`DownloadErrorKind` enum, `src/download_errors.py`, перший юніт-тест) — той самий, що в PR #60 у `master`, але націлений у `dev`.

> ⚠️ **Важливо:** `dev` зараз **позаду** `master` (є його предком — після мерджу PR #59). Гілку відгалужено від `master`, тож цей PR заодно **підтягує `dev` до `master`**: окрім enum-роботи сюди входять усі коміти, що вже в `master`, але яких ще нема в `dev` (TikTok-retry, recovery «без звуку», JSONL-діагностика, H.264, inline тощо). Мерджити «лише enum» окремо в `dev` неможливо без конфліктів, бо enum інтегрується з кодом, якого на `dev` ще нема.

Після мерджу `dev` стане рівним `master` + класифікація помилок.

## Зміст enum-частини

- `src/download_errors.py` — чиста логіка (без `yt_dlp`/`aiogram`), 9 категорій (`AGE_RESTRICTED`, `LOGIN_REQUIRED`, `UNAVAILABLE`, `GEO_BLOCKED`, `RATE_LIMITED`, `UNSUPPORTED`, `NETWORK`, `EXTRACTION`, `UNKNOWN`).
- `classify_download_error()` (ordered first-match-wins) + `is_retriable_error()` (network/extraction/rate-limited).
- Зрозумілі укр-повідомлення per-kind; поле `kind` у `logs/download_issues.jsonl`.
- `tests/test_download_errors.py` — перший юніт-тест (класифікація, retriable, порядок, повнота).

## Перевірка
- `compileall` + `ruff` — зелено; 5/5 тестів проходять (див. також PR #60, CI зелений).

🤖 Generated with [Claude Code](https://claude.com/claude-code)